### PR TITLE
feat: add SEO metadata and PWA support

### DIFF
--- a/gerasena.com/public/manifest.json
+++ b/gerasena.com/public/manifest.json
@@ -1,0 +1,16 @@
+{
+  "name": "Gerasena",
+  "short_name": "Gerasena",
+  "description": "Gere Jogos da Mega-Sena",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "theme_color": "#317EFB",
+  "icons": [
+    {
+      "src": "/globe.svg",
+      "sizes": "any",
+      "type": "image/svg+xml"
+    }
+  ]
+}

--- a/gerasena.com/public/sw.js
+++ b/gerasena.com/public/sw.js
@@ -1,0 +1,18 @@
+const CACHE_NAME = 'gerasena-cache-v1';
+const URLS_TO_CACHE = ['/'];
+
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then(cache => cache.addAll(URLS_TO_CACHE))
+  );
+});
+
+self.addEventListener('activate', event => {
+  event.waitUntil(self.clients.claim());
+});
+
+self.addEventListener('fetch', event => {
+  event.respondWith(
+    caches.match(event.request).then(response => response || fetch(event.request))
+  );
+});

--- a/gerasena.com/src/app/layout.tsx
+++ b/gerasena.com/src/app/layout.tsx
@@ -1,5 +1,6 @@
-import type { Metadata } from "next";
+import type { Metadata, Viewport } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
+import ServiceWorker from "../components/ServiceWorker";
 import "./globals.css";
 
 const geistSans = Geist({
@@ -13,8 +14,53 @@ const geistMono = Geist_Mono({
 });
 
 export const metadata: Metadata = {
-  title: "Gerasena",
+  metadataBase: new URL("https://gerasena.com"),
+  title: {
+    default: "Gerasena",
+    template: "%s | Gerasena",
+  },
   description: "Gere Jogos da Mega-Sena",
+  keywords: ["mega-sena", "loteria", "gerador", "jogos", "sorteio"],
+  authors: [{ name: "Gerasena" }],
+  applicationName: "Gerasena",
+  manifest: "/manifest.json",
+  icons: {
+    icon: "/globe.svg",
+    apple: "/globe.svg",
+  },
+  openGraph: {
+    title: "Gerasena",
+    description: "Gere Jogos da Mega-Sena",
+    url: "https://gerasena.com",
+    siteName: "Gerasena",
+    locale: "pt_BR",
+    type: "website",
+    images: ["/globe.svg"],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "Gerasena",
+    description: "Gere Jogos da Mega-Sena",
+    images: ["/globe.svg"],
+  },
+  alternates: {
+    canonical: "https://gerasena.com",
+  },
+  robots: {
+    index: true,
+    follow: true,
+  },
+  appleWebApp: {
+    capable: true,
+    title: "Gerasena",
+    statusBarStyle: "default",
+  },
+};
+
+export const viewport: Viewport = {
+  width: "device-width",
+  initialScale: 1,
+  themeColor: "#317EFB",
 };
 
 export default function RootLayout({
@@ -23,11 +69,10 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
-      <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
-      >
+    <html lang="pt-BR">
+      <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
         {children}
+        <ServiceWorker />
       </body>
     </html>
   );

--- a/gerasena.com/src/app/robots.ts
+++ b/gerasena.com/src/app/robots.ts
@@ -1,0 +1,13 @@
+import { MetadataRoute } from "next";
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: [
+      {
+        userAgent: "*",
+        allow: "/",
+      },
+    ],
+    sitemap: "https://gerasena.com/sitemap.xml",
+  };
+}

--- a/gerasena.com/src/app/sitemap.ts
+++ b/gerasena.com/src/app/sitemap.ts
@@ -1,0 +1,13 @@
+import { MetadataRoute } from "next";
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const baseUrl = "https://gerasena.com";
+  return [
+    { url: baseUrl, lastModified: new Date() },
+    { url: `${baseUrl}/automatico`, lastModified: new Date() },
+    { url: `${baseUrl}/manual`, lastModified: new Date() },
+    { url: `${baseUrl}/estatisticas`, lastModified: new Date() },
+    { url: `${baseUrl}/historico`, lastModified: new Date() },
+    { url: `${baseUrl}/resultado`, lastModified: new Date() },
+  ];
+}

--- a/gerasena.com/src/components/ServiceWorker.tsx
+++ b/gerasena.com/src/components/ServiceWorker.tsx
@@ -1,0 +1,13 @@
+'use client';
+
+import { useEffect } from 'react';
+
+export default function ServiceWorker() {
+  useEffect(() => {
+    if ('serviceWorker' in navigator) {
+      navigator.serviceWorker.register('/sw.js');
+    }
+  }, []);
+
+  return null;
+}


### PR DESCRIPTION
## Summary
- improve SEO metadata and routing
- add PWA assets for mobile installation
- replace PNG icons with a vector to avoid binary files

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688f0fd1ac28832fa557d64f01a8e778