### PR TITLE
Handle missing database errors during build

### DIFF
--- a/gerasena.com/src/lib/db.ts
+++ b/gerasena.com/src/lib/db.ts
@@ -1,6 +1,20 @@
-import { createClient } from "@libsql/client";
+import { createClient, type Client } from "@libsql/client";
 
-export const db = createClient({
-  url: process.env.TURSO_DATABASE_URL!,
-  authToken: process.env.TURSO_AUTH_TOKEN,
-});
+// Create a libSQL client only when the database URL is available. During build
+// or local development the environment variables might be missing, which would
+// normally cause `createClient` to throw. In that case, fall back to a stubbed
+// client that simply returns empty result sets.
+let db: Client;
+
+if (process.env.TURSO_DATABASE_URL) {
+  db = createClient({
+    url: process.env.TURSO_DATABASE_URL,
+    authToken: process.env.TURSO_AUTH_TOKEN,
+  });
+} else {
+  db = {
+    execute: async () => ({ rows: [] }),
+  } as unknown as Client;
+}
+
+export { db };

--- a/gerasena.com/src/lib/historico.ts
+++ b/gerasena.com/src/lib/historico.ts
@@ -13,11 +13,21 @@ export interface Draw {
 }
 
 export async function getHistorico(limit = 50): Promise<Draw[]> {
-  const res = await db.execute({
-    sql: `SELECT concurso, data, bola1, bola2, bola3, bola4, bola5, bola6 FROM history ORDER BY concurso DESC LIMIT ?`,
-    args: [limit],
-  });
-  return res.rows as unknown as Draw[];
+  try {
+    const res = await db.execute({
+      sql: `SELECT concurso, data, bola1, bola2, bola3, bola4, bola5, bola6 FROM history ORDER BY concurso DESC LIMIT ?`,
+      args: [limit],
+    });
+    return res.rows as unknown as Draw[];
+  } catch (error) {
+    // If the history table is missing (e.g. when the database hasn't been
+    // seeded yet), gracefully fall back to an empty list so that static builds
+    // do not fail.
+    if (error instanceof Error && /no such table: history/i.test(error.message)) {
+      return [];
+    }
+    throw error;
+  }
 }
 
 export function analyzeHistorico(): string[] {


### PR DESCRIPTION
## Summary
- safely query historico table and return empty list when table missing
- fall back to stubbed libSQL client when database config is absent

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688f154326a8832fb4e7f61aaed6906d