### PR TITLE
Allow manual feature value input

### DIFF
--- a/gerasena.com/src/app/manual/page.tsx
+++ b/gerasena.com/src/app/manual/page.tsx
@@ -16,13 +16,23 @@ const GROUPS = [
 
 export default function Manual() {
   const [step, setStep] = useState(0);
-  const [selected, setSelected] = useState<string[]>([]);
+  const [selected, setSelected] = useState<Record<string, number>>({});
   const router = useRouter();
 
   const toggle = (f: string) => {
-    setSelected((prev) =>
-      prev.includes(f) ? prev.filter((p) => p !== f) : [...prev, f]
-    );
+    setSelected((prev) => {
+      const next = { ...prev };
+      if (f in next) {
+        delete next[f];
+      } else {
+        next[f] = 0;
+      }
+      return next;
+    });
+  };
+
+  const setValue = (f: string, value: number) => {
+    setSelected((prev) => ({ ...prev, [f]: value }));
   };
 
   const next = async () => {
@@ -50,6 +60,7 @@ export default function Manual() {
         features={GROUPS[step]}
         selected={selected}
         onToggle={toggle}
+        onChange={setValue}
       />
       <button
         onClick={next}

--- a/gerasena.com/src/components/FeatureSelector.tsx
+++ b/gerasena.com/src/components/FeatureSelector.tsx
@@ -2,22 +2,30 @@
 
 interface Props {
   features: string[];
-  selected: string[];
+  selected: Record<string, number>;
   onToggle: (feature: string) => void;
+  onChange: (feature: string, value: number) => void;
 }
 
-export function FeatureSelector({ features, selected, onToggle }: Props) {
+export function FeatureSelector({ features, selected, onToggle, onChange }: Props) {
   return (
     <div className="grid grid-cols-1 gap-2">
       {features.map((f) => (
         <label key={f} className="flex items-center gap-2">
           <input
             type="checkbox"
-            checked={selected.includes(f)}
+            checked={f in selected}
             onChange={() => onToggle(f)}
             className="h-4 w-4"
           />
           <span className="capitalize">{f.replace(/_/g, " ")}</span>
+          <input
+            type="number"
+            className="ml-auto w-20 rounded border px-1 py-0.5"
+            value={selected[f] ?? ""}
+            disabled={!(f in selected)}
+            onChange={(e) => onChange(f, Number(e.target.value))}
+          />
         </label>
       ))}
     </div>

--- a/gerasena.com/src/lib/genetic.ts
+++ b/gerasena.com/src/lib/genetic.ts
@@ -36,7 +36,7 @@ function fitness(_game: number[]): number {
 }
 
 export function generateGames(
-  _features: string[],
+  _features: Record<string, number>,
   populationSize = 100,
   generations = 50
 ): number[][] {

--- a/gerasena.com/src/lib/historico.ts
+++ b/gerasena.com/src/lib/historico.ts
@@ -20,6 +20,8 @@ export async function getHistorico(limit = 50): Promise<Draw[]> {
   return res.rows as unknown as Draw[];
 }
 
-export function analyzeHistorico(): string[] {
-  return FEATURES;
+export function analyzeHistorico(): Record<string, number> {
+  const result: Record<string, number> = {};
+  FEATURES.forEach((f) => (result[f] = 0));
+  return result;
 }


### PR DESCRIPTION
## Summary
- let manual selection specify values for each feature
- pass feature-value map through generation utilities

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`
- `npm run build` (fails: URL_INVALID: The URL 'undefined' is not in a valid format)


------
https://chatgpt.com/codex/tasks/task_e_688f161837b4832fa16a96097609035f