### PR TITLE
feat: add script to seed mega-sena history

### DIFF
--- a/gerasena.com/package.json
+++ b/gerasena.com/package.json
@@ -8,7 +8,8 @@
     "start": "next start",
     "lint": "next lint",
     "scrape:mega-sena": "node scripts/mega-sena-cron.js",
-    "seed:turso": "node scripts/seed-turso.js"
+    "seed:turso": "node scripts/seed-turso.js",
+    "seed:history": "node scripts/populate-history.js"
   },
   "dependencies": {
     "@libsql/client": "^0.15.10",

--- a/gerasena.com/scripts/populate-history.js
+++ b/gerasena.com/scripts/populate-history.js
@@ -1,0 +1,41 @@
+const fs = require('fs');
+const path = require('path');
+const { createClient } = require('@libsql/client');
+
+const CSV_PATH = path.join(__dirname, '..', 'public', 'mega-sena.csv');
+
+async function main() {
+  const db = createClient({
+    url: process.env.TURSO_DATABASE_URL,
+    authToken: process.env.TURSO_AUTH_TOKEN,
+  });
+
+  await db.execute(`CREATE TABLE IF NOT EXISTS history (
+    concurso INTEGER PRIMARY KEY,
+    data TEXT,
+    bola1 INT,
+    bola2 INT,
+    bola3 INT,
+    bola4 INT,
+    bola5 INT,
+    bola6 INT
+  )`);
+
+  const lines = fs.readFileSync(CSV_PATH, 'utf8').trim().split('\n').slice(1);
+
+  for (const line of lines) {
+    const [concurso, data, b1, b2, b3, b4, b5, b6] = line.split(',');
+    await db.execute({
+      sql: `INSERT OR IGNORE INTO history (concurso, data, bola1, bola2, bola3, bola4, bola5, bola6) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+      args: [concurso, data, b1, b2, b3, b4, b5, b6],
+    });
+  }
+
+  console.log('History table populated');
+  await db.close();
+}
+
+main().catch((err) => {
+  console.error('Failed to populate history table:', err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add utility to seed Mega-Sena history from CSV into Turso DB
- expose new `seed:history` npm script

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688f17915764832fa61ade04a193e37c