### PR TITLE
Translate manual feature names and add tooltips

### DIFF
--- a/gerasena.com/src/components/FeatureSelector.tsx
+++ b/gerasena.com/src/components/FeatureSelector.tsx
@@ -7,18 +7,30 @@ interface Props {
   onChange: (feature: string, value: number) => void;
 }
 
+import { FEATURE_INFO } from "@/lib/features";
+
 export function FeatureSelector({ features, selected, onToggle, onChange }: Props) {
   return (
     <div className="grid grid-cols-1 gap-2">
       {features.map((f) => (
-        <label key={f} className="flex items-center gap-2">
+        <div key={f} className="flex items-center gap-2">
           <input
+            id={`feature-${f}`}
             type="checkbox"
             checked={f in selected}
             onChange={() => onToggle(f)}
             className="h-4 w-4"
           />
-          <span className="capitalize">{f.replace(/_/g, " ")}</span>
+          <label htmlFor={`feature-${f}`} className="capitalize">
+            {FEATURE_INFO[f].label}
+          </label>
+          <button
+            type="button"
+            title={FEATURE_INFO[f].description}
+            className="h-4 w-4 rounded-full bg-gray-200 text-xs"
+          >
+            i
+          </button>
           <input
             type="number"
             className="ml-auto w-20 rounded border px-1 py-0.5"
@@ -26,7 +38,7 @@ export function FeatureSelector({ features, selected, onToggle, onChange }: Prop
             disabled={!(f in selected)}
             onChange={(e) => onChange(f, Number(e.target.value))}
           />
-        </label>
+        </div>
       ))}
     </div>
   );

--- a/gerasena.com/src/lib/features.ts
+++ b/gerasena.com/src/lib/features.ts
@@ -20,3 +20,90 @@ export const FEATURES = [
   "avg_hist_position",
   "tens_group_counts",
 ];
+
+export const FEATURE_INFO: Record<
+  string,
+  { label: string; description: string }
+> = {
+  sum: {
+    label: "Soma",
+    description: "Soma de todos os números escolhidos.",
+  },
+  mean: {
+    label: "Média",
+    description: "Média aritmética dos números escolhidos.",
+  },
+  median: {
+    label: "Mediana",
+    description: "Valor central dos números em ordem.",
+  },
+  mode_hist: {
+    label: "Moda histórica",
+    description: "Número que mais apareceu nos sorteios anteriores.",
+  },
+  range: {
+    label: "Intervalo",
+    description: "Diferença entre o maior e o menor número.",
+  },
+  std: {
+    label: "Desvio padrão",
+    description: "Medida de dispersão em relação à média.",
+  },
+  perc_even: {
+    label: "Percentual de pares",
+    description: "Porcentagem de números pares.",
+  },
+  perc_odd: {
+    label: "Percentual de ímpares",
+    description: "Porcentagem de números ímpares.",
+  },
+  prime_freq: {
+    label: "Frequência de primos",
+    description: "Quantidade de números primos.",
+  },
+  quadrant_counts: {
+    label: "Quadrantes",
+    description:
+      "Distribuição dos números pelos quadrantes do volante.",
+  },
+  sequences: {
+    label: "Sequências",
+    description: "Quantidade de números consecutivos.",
+  },
+  avg_distance: {
+    label: "Distância média",
+    description: "Distância média entre números consecutivos.",
+  },
+  min_distance: {
+    label: "Distância mínima",
+    description: "Menor distância entre números consecutivos.",
+  },
+  max_distance: {
+    label: "Distância máxima",
+    description: "Maior distância entre números consecutivos.",
+  },
+  repeat_prev: {
+    label: "Repetições",
+    description: "Quantidade de números repetidos do último concurso.",
+  },
+  avg_hist_freq: {
+    label: "Freq. histórica média",
+    description: "Média de frequência histórica dos números.",
+  },
+  sum_digits: {
+    label: "Soma dos dígitos",
+    description: "Soma dos dígitos de cada número.",
+  },
+  last_digit_counts: {
+    label: "Dígitos finais",
+    description: "Distribuição dos dígitos finais.",
+  },
+  avg_hist_position: {
+    label: "Posição histórica média",
+    description: "Média das posições históricas nos sorteios.",
+  },
+  tens_group_counts: {
+    label: "Grupos de dezena",
+    description: "Distribuição por grupos de dezena.",
+  },
+};


### PR DESCRIPTION
## Summary
- translate manual feature names to Portuguese and add descriptions
- show feature descriptions as tooltips in manual selection

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688f1a548594832fa2ed7426b7d22c6e