### PR TITLE
feat: add cron API to sync history

### DIFF
--- a/gerasena.com/src/app/api/cron/route.ts
+++ b/gerasena.com/src/app/api/cron/route.ts
@@ -1,0 +1,37 @@
+import { NextResponse } from "next/server";
+import { db } from "@/lib/db";
+import fs from "node:fs/promises";
+import path from "node:path";
+
+export async function GET() {
+  try {
+    const csvPath = path.join(process.cwd(), "public", "mega-sena.csv");
+    const content = await fs.readFile(csvPath, "utf8");
+    const lines = content.trim().split("\n").slice(1);
+
+    await db.execute(`CREATE TABLE IF NOT EXISTS history (
+      concurso INTEGER PRIMARY KEY,
+      data TEXT,
+      bola1 INT,
+      bola2 INT,
+      bola3 INT,
+      bola4 INT,
+      bola5 INT,
+      bola6 INT
+    )`);
+
+    for (const line of lines) {
+      const [concurso, data, b1, b2, b3, b4, b5, b6] = line.split(",");
+      await db.execute({
+        sql: `INSERT OR IGNORE INTO history (concurso, data, bola1, bola2, bola3, bola4, bola5, bola6)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+        args: [concurso, data, b1, b2, b3, b4, b5, b6],
+      });
+    }
+
+    return NextResponse.json({ ok: true });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}


### PR DESCRIPTION
## Summary
- add /api/cron route to load mega-sena.csv into Turso history table

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688f1cb5ce6c832f822e74c0c7f58356