### PR TITLE
Store generated games in gerador table

### DIFF
--- a/gerasena.com/scripts/seed-turso.js
+++ b/gerasena.com/scripts/seed-turso.js
@@ -21,9 +21,14 @@ async function seed() {
     bola6 INT
   )`);
 
-  await db.execute(`CREATE TABLE IF NOT EXISTS generated_numbers (
+  await db.execute(`CREATE TABLE IF NOT EXISTS gerador (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
-    numbers TEXT NOT NULL,
+    bola1 INT,
+    bola2 INT,
+    bola3 INT,
+    bola4 INT,
+    bola5 INT,
+    bola6 INT,
     created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
   )`);
 

--- a/gerasena.com/src/lib/generated.ts
+++ b/gerasena.com/src/lib/generated.ts
@@ -8,20 +8,18 @@ export interface GeneratedRow {
 
 export async function saveGenerated(numbers: number[]): Promise<void> {
   await db.execute({
-    sql: `INSERT INTO generated_numbers (numbers, created_at) VALUES (?, datetime('now'))`,
-    args: [numbers.join(',')],
+    sql: `INSERT INTO gerador (bola1, bola2, bola3, bola4, bola5, bola6, created_at) VALUES (?, ?, ?, ?, ?, ?, datetime('now'))`,
+    args: numbers,
   });
 }
 
 export async function getGenerated(): Promise<GeneratedRow[]> {
   const res = await db.execute(
-    `SELECT id, numbers, created_at FROM generated_numbers ORDER BY id DESC`
+    `SELECT id, bola1, bola2, bola3, bola4, bola5, bola6, created_at FROM gerador ORDER BY id DESC`
   );
   return res.rows.map((r: any) => ({
     id: r.id,
-    numbers: String(r.numbers)
-      .split(',')
-      .map((n) => parseInt(n, 10)),
+    numbers: [r.bola1, r.bola2, r.bola3, r.bola4, r.bola5, r.bola6].map((n: any) => parseInt(n, 10)),
     created_at: r.created_at,
   }));
 }


### PR DESCRIPTION
## Summary
- persist generated games in new `gerador` table with individual ball columns
- seed `gerador` table alongside history data

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688f1d92457c832fa1a529c1fe33dee5