### PR TITLE
Consider past 50 games in evaluation

### DIFF
--- a/gerasena.com/src/app/api/historico/route.ts
+++ b/gerasena.com/src/app/api/historico/route.ts
@@ -1,0 +1,7 @@
+import { NextResponse } from "next/server";
+import { getHistorico } from "@/lib/historico";
+
+export async function GET() {
+  const draws = await getHistorico(50);
+  return NextResponse.json(draws);
+}

--- a/gerasena.com/src/app/automatico/page.tsx
+++ b/gerasena.com/src/app/automatico/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 import { useEffect } from "react";
 import { useRouter } from "next/navigation";
-import { analyzeHistorico } from "@/lib/historico";
+import { analyzeHistorico, type Draw } from "@/lib/historico";
 import { generateGames } from "@/lib/genetic";
 import { evaluateGames } from "@/lib/evaluator";
 
@@ -12,7 +12,17 @@ export default function Automatico() {
     async function run() {
       const features = await analyzeHistorico();
       const games = generateGames(features);
-      const evaluated = evaluateGames(games);
+      const res = await fetch("/api/historico");
+      const draws: Draw[] = await res.json();
+      const history = draws.map((d) => [
+        d.bola1,
+        d.bola2,
+        d.bola3,
+        d.bola4,
+        d.bola5,
+        d.bola6,
+      ]);
+      const evaluated = evaluateGames(games, history);
       for (const g of evaluated) {
         fetch("/api/generated", {
           method: "POST",

--- a/gerasena.com/src/app/manual/page.tsx
+++ b/gerasena.com/src/app/manual/page.tsx
@@ -6,6 +6,7 @@ import { FeatureSelector } from "@/components/FeatureSelector";
 import { generateGames } from "@/lib/genetic";
 import { evaluateGames } from "@/lib/evaluator";
 import Link from "next/link";
+import type { Draw } from "@/lib/historico";
 
 const GROUPS = [
   FEATURES.slice(0, 4),
@@ -41,7 +42,17 @@ export default function Manual() {
       setStep(step + 1);
     } else {
       const games = generateGames(selected);
-      const evaluated = evaluateGames(games);
+      const res = await fetch("/api/historico");
+      const draws: Draw[] = await res.json();
+      const history = draws.map((d) => [
+        d.bola1,
+        d.bola2,
+        d.bola3,
+        d.bola4,
+        d.bola5,
+        d.bola6,
+      ]);
+      const evaluated = evaluateGames(games, history);
       evaluated.forEach((g) => {
         fetch("/api/generated", {
           method: "POST",

--- a/gerasena.com/src/lib/evaluator.ts
+++ b/gerasena.com/src/lib/evaluator.ts
@@ -5,15 +5,31 @@ export interface ScoredGame {
   score: number;
 }
 
-function evaluateGame(numbers: number[]): number {
+function evaluateGame(
+  numbers: number[],
+  freq: number[],
+  historyLength: number
+): number {
   const tensor = tf.tensor1d(numbers);
   const sum = tensor.sum().arraySync() as number;
   tensor.dispose();
-  return sum / (60 * 6);
+  const avgFreq =
+    numbers.reduce((acc, n) => acc + freq[n - 1], 0) / numbers.length;
+  const rarity = historyLength ? 1 - avgFreq / historyLength : 1;
+  return (sum / (60 * 6)) * rarity;
 }
 
-export function evaluateGames(games: number[][]): ScoredGame[] {
+export function evaluateGames(
+  games: number[][],
+  history: number[][]
+): ScoredGame[] {
+  const freq = Array(60).fill(0);
+  history.flat().forEach((n) => {
+    if (n >= 1 && n <= 60) freq[n - 1]++;
+  });
+  const len = history.length;
+
   return games
-    .map((g) => ({ numbers: g, score: evaluateGame(g) }))
+    .map((g) => ({ numbers: g, score: evaluateGame(g, freq, len) }))
     .sort((a, b) => b.score - a.score);
 }


### PR DESCRIPTION
## Summary
- score games by weighing numbers against frequency in last 50 draws
- add `/api/historico` endpoint to serve recent draw history
- fetch history before evaluating games in manual and automatic flows

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688f21693ccc832f952aeca16ca9937c