### PR TITLE
feat: add lazy loading for history page

### DIFF
--- a/gerasena.com/src/app/api/historico/route.ts
+++ b/gerasena.com/src/app/api/historico/route.ts
@@ -1,7 +1,10 @@
 import { NextResponse } from "next/server";
 import { getHistorico } from "@/lib/historico";
 
-export async function GET() {
-  const draws = await getHistorico(50);
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const limit = parseInt(searchParams.get("limit") ?? "50", 10);
+  const offset = parseInt(searchParams.get("offset") ?? "0", 10);
+  const draws = await getHistorico(limit, offset);
   return NextResponse.json(draws);
 }

--- a/gerasena.com/src/app/historico/page.tsx
+++ b/gerasena.com/src/app/historico/page.tsx
@@ -1,36 +1,20 @@
 import { getHistorico } from "@/lib/historico";
 import Link from "next/link";
+import HistoricoTable from "@/components/HistoricoTable";
 
 export default async function Historico() {
   const draws = await getHistorico(50);
   return (
     <main className="mx-auto max-w-3xl p-4 text-center">
       <h2 className="mb-4 text-xl font-semibold">Histórico</h2>
-      <table className="w-full text-sm text-center">
-        <thead>
-          <tr>
-            <th className="px-2 py-1">Concurso</th>
-            <th className="px-2 py-1">Data</th>
-            <th className="px-2 py-1">Dezenas</th>
-          </tr>
-        </thead>
-        <tbody>
-          {draws.map((d) => (
-            <tr key={d.concurso} className="odd:bg-gray-100 text-green-500">
-              <td className="px-2 py-1">{d.concurso}</td>
-              <td className="px-2 py-1">{d.data}</td>
-              <td className="px-2 py-1">
-                {[d.bola1, d.bola2, d.bola3, d.bola4, d.bola5, d.bola6].join(", ")}
-              </td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
+      <HistoricoTable initialDraws={draws} />
       <br />
-      <Link href="/"
+      <Link
+        href="/"
         className="rounded bg-green-600 px-4 py-2 text-white text-center hover:bg-green-700"
-
-      >Voltar</Link>
+      >
+        Voltar
+      </Link>
     </main>
   );
 }

--- a/gerasena.com/src/components/HistoricoTable.tsx
+++ b/gerasena.com/src/components/HistoricoTable.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { Draw } from "@/lib/historico";
+
+interface Props {
+  initialDraws: Draw[];
+}
+
+export default function HistoricoTable({ initialDraws }: Props) {
+  const [draws, setDraws] = useState<Draw[]>(initialDraws);
+  const [offset, setOffset] = useState(initialDraws.length);
+  const [hasMore, setHasMore] = useState(true);
+  const [loading, setLoading] = useState(false);
+  const loaderRef = useRef<HTMLDivElement | null>(null);
+
+  const loadMore = useCallback(async () => {
+    setLoading(true);
+    const res = await fetch(`/api/historico?limit=50&offset=${offset}`);
+    const data: Draw[] = await res.json();
+    setDraws((prev) => [...prev, ...data]);
+    setOffset((prev) => prev + data.length);
+    if (data.length === 0) {
+      setHasMore(false);
+    }
+    setLoading(false);
+  }, [offset]);
+
+  useEffect(() => {
+    if (!loaderRef.current) return;
+    const observer = new IntersectionObserver((entries) => {
+      if (entries[0].isIntersecting && !loading && hasMore) {
+        loadMore();
+      }
+    });
+    const el = loaderRef.current;
+    observer.observe(el);
+    return () => observer.unobserve(el);
+  }, [loading, hasMore, loadMore]);
+
+  return (
+    <>
+      <table className="w-full text-sm text-center">
+        <thead>
+          <tr>
+            <th className="px-2 py-1">Concurso</th>
+            <th className="px-2 py-1">Data</th>
+            <th className="px-2 py-1">Dezenas</th>
+          </tr>
+        </thead>
+        <tbody>
+          {draws.map((d) => (
+            <tr key={d.concurso} className="odd:bg-gray-100 text-green-500">
+              <td className="px-2 py-1">{d.concurso}</td>
+              <td className="px-2 py-1">{d.data}</td>
+              <td className="px-2 py-1">
+                {[d.bola1, d.bola2, d.bola3, d.bola4, d.bola5, d.bola6].join(", ")}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      <div ref={loaderRef} className="py-4">
+        {loading && <p>Carregando...</p>}
+        {!hasMore && <p>Fim do histórico</p>}
+      </div>
+    </>
+  );
+}
+

--- a/gerasena.com/src/lib/historico.ts
+++ b/gerasena.com/src/lib/historico.ts
@@ -13,11 +13,14 @@ export interface Draw {
   bola6: number;
 }
 
-export async function getHistorico(limit = 50): Promise<Draw[]> {
+export async function getHistorico(
+  limit = 50,
+  offset = 0
+): Promise<Draw[]> {
   try {
     const res = await db.execute({
-      sql: `SELECT concurso, data, bola1, bola2, bola3, bola4, bola5, bola6 FROM history ORDER BY concurso DESC LIMIT ?`,
-      args: [limit],
+      sql: `SELECT concurso, data, bola1, bola2, bola3, bola4, bola5, bola6 FROM history ORDER BY concurso DESC LIMIT ? OFFSET ?`,
+      args: [limit, offset],
     });
     return res.rows as unknown as Draw[];
   } catch (error) {


### PR DESCRIPTION
## Summary
- support pagination in historic data API
- add HistoricoTable component with infinite scroll
- update history page to use lazy loaded table

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688f2d7b2414832fb068e57ef615d33d