### PR TITLE
Ensure unique game generation using Set

### DIFF
--- a/gerasena.com/src/lib/evaluator.ts
+++ b/gerasena.com/src/lib/evaluator.ts
@@ -29,11 +29,17 @@ export function evaluateGames(
   });
   const len = history.length;
 
-  const uniqueGames = Array.from(
-    new Map(games.map((g) => [g.join(","), g])).values()
-  );
+  const unique: number[][] = [];
+  const seen = new Set<string>();
+  for (const g of games) {
+    const key = g.join(",");
+    if (!seen.has(key)) {
+      seen.add(key);
+      unique.push(g);
+    }
+  }
 
-  return uniqueGames
+  return unique
     .map((g) => ({ numbers: g, score: evaluateGame(g, freq, len) }))
     .sort((a, b) => b.score - a.score);
 }

--- a/gerasena.com/src/lib/genetic.ts
+++ b/gerasena.com/src/lib/genetic.ts
@@ -92,5 +92,14 @@ export function generateGames(
     population.push(...survivors);
   }
 
-  return Array.from(new Map(population.map((g) => [gameKey(g), g])).values());
+  const unique: number[][] = [];
+  const finalSeen = new Set<string>();
+  for (const g of population) {
+    const key = gameKey(g);
+    if (!finalSeen.has(key)) {
+      finalSeen.add(key);
+      unique.push(g);
+    }
+  }
+  return unique;
 }


### PR DESCRIPTION
## Summary
- ensure unique lottery game generation by tracking seen combos with a Set
- deduplicate games before evaluation so each set of numbers is scored only once

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688f3798e0c0832fa19d87ababc9a680