### PR TITLE
Ensure unique Mega-Sena games by sorting before dedup

### DIFF
--- a/gerasena.com/src/lib/evaluator.ts
+++ b/gerasena.com/src/lib/evaluator.ts
@@ -32,10 +32,11 @@ export function evaluateGames(
   const unique: number[][] = [];
   const seen = new Set<string>();
   for (const g of games) {
-    const key = g.join(",");
+    const sorted = [...g].sort((a, b) => a - b);
+    const key = sorted.join(",");
     if (!seen.has(key)) {
       seen.add(key);
-      unique.push(g);
+      unique.push(sorted);
     }
   }
 

--- a/gerasena.com/src/lib/genetic.ts
+++ b/gerasena.com/src/lib/genetic.ts
@@ -40,7 +40,7 @@ function fitness(_game: number[]): number {
 }
 
 function gameKey(game: number[]): string {
-  return game.join(",");
+  return [...game].sort((a, b) => a - b).join(",");
 }
 
 export function generateGames(
@@ -95,10 +95,11 @@ export function generateGames(
   const unique: number[][] = [];
   const finalSeen = new Set<string>();
   for (const g of population) {
-    const key = gameKey(g);
+    const sorted = [...g].sort((a, b) => a - b);
+    const key = sorted.join(",");
     if (!finalSeen.has(key)) {
       finalSeen.add(key);
-      unique.push(g);
+      unique.push(sorted);
     }
   }
   return unique;


### PR DESCRIPTION
## Summary
- Sort game numbers before generating uniqueness keys in evaluator
- Sort games prior to key generation and final deduplication in genetic algorithm

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688f39e648c0832fbcf109282d9a0754