### PR TITLE
Add historical repetition feature and sum range filter

### DIFF
--- a/gerasena.com/src/app/manual/page.tsx
+++ b/gerasena.com/src/app/manual/page.tsx
@@ -8,17 +8,14 @@ import { evaluateGames } from "@/lib/evaluator";
 import Link from "next/link";
 import type { Draw } from "@/lib/historico";
 
-const GROUPS = [
-  FEATURES.slice(0, 4),
-  FEATURES.slice(4, 8),
-  FEATURES.slice(8, 12),
-  FEATURES.slice(12, 16),
-  FEATURES.slice(16, 20),
-];
+const GROUP_SIZE = 4;
+const GROUPS = Array.from({ length: Math.ceil(FEATURES.length / GROUP_SIZE) }, (_v, i) =>
+  FEATURES.slice(i * GROUP_SIZE, i * GROUP_SIZE + GROUP_SIZE)
+);
 
 export default function Manual() {
   const [step, setStep] = useState(0);
-  const [selected, setSelected] = useState<Record<string, number>>({});
+  const [selected, setSelected] = useState<Record<string, number | [number, number]>>({});
   const router = useRouter();
 
   const toggle = (f: string) => {
@@ -27,13 +24,13 @@ export default function Manual() {
       if (f in next) {
         delete next[f];
       } else {
-        next[f] = 0;
+        next[f] = f === "sum" ? [0, 0] : 0;
       }
       return next;
     });
   };
 
-  const setValue = (f: string, value: number) => {
+  const setValue = (f: string, value: number | [number, number]) => {
     setSelected((prev) => ({ ...prev, [f]: value }));
   };
 

--- a/gerasena.com/src/components/FeatureSelector.tsx
+++ b/gerasena.com/src/components/FeatureSelector.tsx
@@ -2,9 +2,9 @@
 
 interface Props {
   features: string[];
-  selected: Record<string, number>;
+  selected: Record<string, number | [number, number]>;
   onToggle: (feature: string) => void;
-  onChange: (feature: string, value: number) => void;
+  onChange: (feature: string, value: number | [number, number]) => void;
 }
 
 import { FEATURE_INFO } from "@/lib/features";
@@ -12,34 +12,64 @@ import { FEATURE_INFO } from "@/lib/features";
 export function FeatureSelector({ features, selected, onToggle, onChange }: Props) {
   return (
     <div className="grid grid-cols-1 gap-2">
-      {features.map((f) => (
-        <div key={f} className="flex items-center gap-2">
-          <input
-            id={`feature-${f}`}
-            type="checkbox"
-            checked={f in selected}
-            onChange={() => onToggle(f)}
-            className="h-4 w-4"
-          />
-          <label htmlFor={`feature-${f}`} className="capitalize">
-            {FEATURE_INFO[f].label}
-          </label>
-          <button
-            type="button"
-            title={FEATURE_INFO[f].description}
-            className="h-4 w-4 rounded-full bg-gray-200 text-xs text-black"
-          >
-            i
-          </button>
-          <input
-            type="number"
-            className="ml-auto w-20 rounded border px-1 py-0.5"
-            value={selected[f] ?? ""}
-            disabled={!(f in selected)}
-            onChange={(e) => onChange(f, Number(e.target.value))}
-          />
-        </div>
-      ))}
+      {features.map((f) => {
+        const isRange = f === "sum";
+        const active = f in selected;
+        const value = selected[f];
+        const [min, max] = Array.isArray(value) ? value : ["", ""];
+        return (
+          <div key={f} className="flex items-center gap-2">
+            <input
+              id={`feature-${f}`}
+              type="checkbox"
+              checked={active}
+              onChange={() => onToggle(f)}
+              className="h-4 w-4"
+            />
+            <label htmlFor={`feature-${f}`} className="capitalize">
+              {FEATURE_INFO[f].label}
+            </label>
+            <button
+              type="button"
+              title={FEATURE_INFO[f].description}
+              className="h-4 w-4 rounded-full bg-gray-200 text-xs text-black"
+            >
+              i
+            </button>
+            {isRange ? (
+              <div className="ml-auto flex items-center gap-1">
+                <input
+                  type="number"
+                  className="w-20 rounded border px-1 py-0.5"
+                  value={min as number | string}
+                  disabled={!active}
+                  onChange={(e) =>
+                    onChange(f, [Number(e.target.value), Number(max || 0)])
+                  }
+                />
+                <span>-</span>
+                <input
+                  type="number"
+                  className="w-20 rounded border px-1 py-0.5"
+                  value={max as number | string}
+                  disabled={!active}
+                  onChange={(e) =>
+                    onChange(f, [Number(min || 0), Number(e.target.value)])
+                  }
+                />
+              </div>
+            ) : (
+              <input
+                type="number"
+                className="ml-auto w-20 rounded border px-1 py-0.5"
+                value={(value as number) ?? ""}
+                disabled={!active}
+                onChange={(e) => onChange(f, Number(e.target.value))}
+              />
+            )}
+          </div>
+        );
+      })}
     </div>
   );
 }

--- a/gerasena.com/src/lib/features.ts
+++ b/gerasena.com/src/lib/features.ts
@@ -14,6 +14,7 @@ export const FEATURES = [
   "min_distance",
   "max_distance",
   "repeat_prev",
+  "repeat_hist",
   "avg_hist_freq",
   "sum_digits",
   "last_digit_counts",
@@ -85,6 +86,10 @@ export const FEATURE_INFO: Record<
   repeat_prev: {
     label: "Repetições",
     description: "Quantidade de números repetidos do último concurso.",
+  },
+  repeat_hist: {
+    label: "Repetidas no histórico",
+    description: "Quantidade de números já sorteados anteriormente.",
   },
   avg_hist_freq: {
     label: "Freq. histórica média",

--- a/gerasena.com/src/lib/genetic.ts
+++ b/gerasena.com/src/lib/genetic.ts
@@ -44,7 +44,7 @@ function gameKey(game: number[]): string {
 }
 
 export function generateGames(
-  _features: Record<string, number>,
+  _features: Record<string, number | [number, number]>,
   populationSize = 100,
   generations = 50
 ): number[][] {

--- a/gerasena.com/src/lib/historico.ts
+++ b/gerasena.com/src/lib/historico.ts
@@ -79,6 +79,7 @@ function computeFeatures(
   const minDist = Math.min(...diffs);
   const maxDist = Math.max(...diffs);
   const repeatPrev = prevDraw.filter((n) => sorted.includes(n)).length;
+  const repeatHist = sorted.filter((n) => histFreq[n - 1] > 0).length;
   const avgHistFreq =
     sorted.reduce((acc, n) => acc + histFreq[n - 1], 0) / sorted.length;
   const sumDigits = sorted.reduce(
@@ -115,6 +116,7 @@ function computeFeatures(
     minDist,
     maxDist,
     repeatPrev,
+    repeatHist,
     avgHistFreq,
     sumDigits,
     lastDigitStd,


### PR DESCRIPTION
## Summary
- track numbers repeated in historical draws via new repeat_hist feature
- extend manual selection UI with dynamic feature grouping and sum range inputs
- adapt FeatureSelector to handle range-based sum filter

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688f5d6b3184832fa816d720a3ef140b