### PR TITLE
fix: apply sum range feature to game generation

### DIFF
--- a/gerasena.com/src/lib/genetic.ts
+++ b/gerasena.com/src/lib/genetic.ts
@@ -48,10 +48,13 @@ export function generateGames(
   populationSize = 100,
   generations = 50
 ): number[][] {
+  const sumRange = Array.isArray(_features.sum) ? _features.sum : null;
   const population: number[][] = [];
   const seen = new Set<string>();
   while (population.length < populationSize) {
     const game = randomGame();
+    const sum = game.reduce((a, b) => a + b, 0);
+    if (sumRange && (sum < sumRange[0] || sum > sumRange[1])) continue;
     const key = gameKey(game);
     if (!seen.has(key)) {
       seen.add(key);
@@ -81,6 +84,8 @@ export function generateGames(
       const b = survivors[rand(0, survivors.length - 1)];
       const child = crossover(a, b);
       mutate(child);
+      const sum = child.reduce((acc, n) => acc + n, 0);
+      if (sumRange && (sum < sumRange[0] || sum > sumRange[1])) continue;
       const key = gameKey(child);
       if (!survivorKeys.has(key)) {
         survivorKeys.add(key);
@@ -96,6 +101,8 @@ export function generateGames(
   const finalSeen = new Set<string>();
   for (const g of population) {
     const sorted = [...g].sort((a, b) => a - b);
+    const sum = sorted.reduce((acc, n) => acc + n, 0);
+    if (sumRange && (sum < sumRange[0] || sum > sumRange[1])) continue;
     const key = sorted.join(",");
     if (!finalSeen.has(key)) {
       finalSeen.add(key);


### PR DESCRIPTION
## Summary
- ensure generateGames respects a provided sum range by filtering initial, crossover, and final games

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_688f615e2c04832f9c5d2de3eeb2e1af