### PR TITLE
feat: add concurso selection for manual generator

### DIFF
--- a/gerasena.com/src/app/api/historico/route.ts
+++ b/gerasena.com/src/app/api/historico/route.ts
@@ -5,6 +5,8 @@ export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
   const limit = parseInt(searchParams.get("limit") ?? "50", 10);
   const offset = parseInt(searchParams.get("offset") ?? "0", 10);
-  const draws = await getHistorico(limit, offset);
+  const beforeParam = searchParams.get("before");
+  const before = beforeParam ? parseInt(beforeParam, 10) : undefined;
+  const draws = await getHistorico(limit, offset, before);
   return NextResponse.json(draws);
 }

--- a/gerasena.com/src/app/manual/page.tsx
+++ b/gerasena.com/src/app/manual/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { useState } from "react";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import { FEATURES } from "@/lib/features";
 import { FeatureSelector } from "@/components/FeatureSelector";
 import { generateGames } from "@/lib/genetic";
@@ -17,6 +17,9 @@ export default function Manual() {
   const [step, setStep] = useState(0);
   const [selected, setSelected] = useState<Record<string, number | [number, number]>>({});
   const router = useRouter();
+  const searchParams = useSearchParams();
+  const concursoParam = searchParams.get("concurso");
+  const baseConcurso = concursoParam ? parseInt(concursoParam, 10) : undefined;
 
   const toggle = (f: string) => {
     setSelected((prev) => {
@@ -39,7 +42,9 @@ export default function Manual() {
       setStep(step + 1);
     } else {
       const games = generateGames(selected);
-      const res = await fetch("/api/historico");
+      const res = await fetch(
+        `/api/historico?limit=50${baseConcurso ? `&before=${baseConcurso}` : ""}`
+      );
       const draws: Draw[] = await res.json();
       const history = draws.map((d) => [
         d.bola1,

--- a/gerasena.com/src/app/page.tsx
+++ b/gerasena.com/src/app/page.tsx
@@ -1,16 +1,25 @@
 "use client";
 import Link from "next/link";
 import Image from "next/image";
+import { useState } from "react";
 
 export default function Home() {
+  const [concurso, setConcurso] = useState("");
   return (
     <main className="flex min-h-screen flex-col items-center justify-center gap-6 p-6">
       <Image src="/logo.png" alt="Gerasena" width={100} height={100} />
       <h1 className="text-2xl font-bold">Gerasena</h1>
       <h1 className="text-2xl font-bold">Gere Jogos da Mega-Sena</h1>
       <div className="flex gap-4 flex-col">
+        <input
+          type="number"
+          value={concurso}
+          onChange={(e) => setConcurso(e.target.value)}
+          placeholder="Concurso base"
+          className="rounded border px-4 py-2"
+        />
         <Link
-          href="/manual"
+          href={`/manual${concurso ? `?concurso=${concurso}` : ""}`}
           className="rounded bg-blue-600 px-4 py-2 text-white text-center hover:bg-blue-700"
         >
           Manual

--- a/gerasena.com/src/lib/historico.ts
+++ b/gerasena.com/src/lib/historico.ts
@@ -15,12 +15,15 @@ export interface Draw {
 
 export async function getHistorico(
   limit = 50,
-  offset = 0
+  offset = 0,
+  before?: number
 ): Promise<Draw[]> {
   try {
     const res = await db.execute({
-      sql: `SELECT concurso, data, bola1, bola2, bola3, bola4, bola5, bola6 FROM history ORDER BY concurso DESC LIMIT ? OFFSET ?`,
-      args: [limit, offset],
+      sql: before
+        ? `SELECT concurso, data, bola1, bola2, bola3, bola4, bola5, bola6 FROM history WHERE concurso < ? ORDER BY concurso DESC LIMIT ? OFFSET ?`
+        : `SELECT concurso, data, bola1, bola2, bola3, bola4, bola5, bola6 FROM history ORDER BY concurso DESC LIMIT ? OFFSET ?`,
+      args: before ? [before, limit, offset] : [limit, offset],
     });
     return res.rows as unknown as Draw[];
   } catch (error) {


### PR DESCRIPTION
## Summary
- allow choosing a base concurso on the home page when navigating to manual generation
- load historical draws before the chosen concurso for manual predictions
- support optional `before` filter in historico API and data access

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688f6ace6a54832f882faa1f1984fcdb