### PR TITLE
refactor: defer tensorflow imports

### DIFF
--- a/gerasena.com/src/app/automatico/page.tsx
+++ b/gerasena.com/src/app/automatico/page.tsx
@@ -1,15 +1,16 @@
 "use client";
 import { useEffect } from "react";
 import { useRouter } from "next/navigation";
-import { analyzeHistorico, type Draw } from "@/lib/historico";
 import { generateGames } from "@/lib/genetic";
-import { evaluateGames } from "@/lib/evaluator";
+import type { Draw } from "@/lib/historico";
 
 export default function Automatico() {
   const router = useRouter();
 
   useEffect(() => {
     async function run() {
+      const { analyzeHistorico } = await import("@/lib/historico");
+      const { evaluateGames } = await import("@/lib/evaluator");
       const features = await analyzeHistorico();
       const games = generateGames(features);
       const res = await fetch("/api/historico");

--- a/gerasena.com/src/app/manual/page.tsx
+++ b/gerasena.com/src/app/manual/page.tsx
@@ -1,10 +1,9 @@
 "use client";
-import { useState } from "react";
+import { useState, Suspense } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { FEATURES } from "@/lib/features";
 import { FeatureSelector } from "@/components/FeatureSelector";
 import { generateGames } from "@/lib/genetic";
-import { evaluateGames } from "@/lib/evaluator";
 import Link from "next/link";
 import type { Draw } from "@/lib/historico";
 
@@ -13,7 +12,7 @@ const GROUPS = Array.from({ length: Math.ceil(FEATURES.length / GROUP_SIZE) }, (
   FEATURES.slice(i * GROUP_SIZE, i * GROUP_SIZE + GROUP_SIZE)
 );
 
-export default function Manual() {
+function ManualContent() {
   const [step, setStep] = useState(0);
   const [selected, setSelected] = useState<Record<string, number | [number, number]>>({});
   const router = useRouter();
@@ -54,6 +53,7 @@ export default function Manual() {
         d.bola5,
         d.bola6,
       ]);
+      const { evaluateGames } = await import("@/lib/evaluator");
       const evaluated = evaluateGames(games, history);
       evaluated.forEach((g) => {
         fetch("/api/generated", {
@@ -88,5 +88,13 @@ export default function Manual() {
 
       >Voltar</Link>
     </main>
+  );
+}
+
+export default function Manual() {
+  return (
+    <Suspense fallback={<p>Carregando...</p>}>
+      <ManualContent />
+    </Suspense>
   );
 }

--- a/gerasena.com/src/lib/historico.ts
+++ b/gerasena.com/src/lib/historico.ts
@@ -1,6 +1,6 @@
 import { db } from "./db";
 import { FEATURES } from "./features";
-import * as tf from "@tensorflow/tfjs";
+import type * as tfTypes from "@tensorflow/tfjs";
 
 export interface Draw {
   concurso: number;
@@ -131,6 +131,7 @@ function computeFeatures(
 export async function analyzeHistorico(): Promise<
   Record<string, number | [number, number]>
 > {
+  const tf: typeof tfTypes = await import("@tensorflow/tfjs");
   const result: Record<string, number | [number, number]> = {};
   FEATURES.forEach((f) => (result[f] = 0));
   const historico = await getHistorico(50);
@@ -184,7 +185,7 @@ export async function analyzeHistorico(): Promise<
   model.compile({ loss: "meanSquaredError", optimizer: tf.train.adam(0.1) });
   await model.fit(xs, ys, { epochs: 100, verbose: 0 });
   const last = tf.tensor2d([featureVectors[featureVectors.length - 1]]);
-  const prediction = model.predict(last) as tf.Tensor;
+  const prediction = model.predict(last) as tfTypes.Tensor;
   const values = Array.from(prediction.dataSync());
 
   FEATURES.forEach((f, i) => {


### PR DESCRIPTION
## Summary
- defer TensorFlow-heavy modules to runtime and wrap manual page in suspense
- load TensorFlow lazily to avoid build-time crashes

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688f6c822ce0832fafa12664d539f6f3