### PR TITLE
feat: limit automatic mode to chosen contest

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Gerasena.com é uma aplicação completa para geração e análise de jogos da M
 
 - **Geração de jogos**
   - **Manual:** o usuário escolhe características estatísticas (soma, média, frequência histórica etc.) e o sistema cria combinações a partir desses critérios.
-  - **Automática:** o módulo `analyzeHistorico` usa [TensorFlow.js](https://www.tensorflow.org/js) para analisar os últimos sorteios, inferir os melhores parâmetros e gerar combinações automaticamente.
+  - **Automática:** o módulo `analyzeHistorico` usa [TensorFlow.js](https://www.tensorflow.org/js) para analisar os 50 sorteios anteriores ao concurso informado (ou os últimos disponíveis) e gerar combinações automaticamente.
   - As combinações são avaliadas (`evaluator.ts`) e salvas na tabela `gerador` do banco de dados.
 - **Consulta de resultados**
   - Página de **histórico** com os últimos concursos e possibilidade de paginação via `/api/historico`.

--- a/gerasena.com/src/app/automatico/page.tsx
+++ b/gerasena.com/src/app/automatico/page.tsx
@@ -1,19 +1,24 @@
 "use client";
-import { useEffect } from "react";
-import { useRouter } from "next/navigation";
+import { useEffect, Suspense } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
 import { generateGames } from "@/lib/genetic";
 import type { Draw } from "@/lib/historico";
 
-export default function Automatico() {
+function AutomaticoContent() {
   const router = useRouter();
+  const searchParams = useSearchParams();
+  const concursoParam = searchParams.get("concurso");
+  const baseConcurso = concursoParam ? parseInt(concursoParam, 10) : undefined;
 
   useEffect(() => {
     async function run() {
       const { analyzeHistorico } = await import("@/lib/historico");
       const { evaluateGames } = await import("@/lib/evaluator");
-      const features = await analyzeHistorico();
+      const features = await analyzeHistorico(baseConcurso);
       const games = generateGames(features);
-      const res = await fetch("/api/historico");
+      const res = await fetch(
+        `/api/historico?limit=50${baseConcurso ? `&before=${baseConcurso}` : ""}`
+      );
       const draws: Draw[] = await res.json();
       const history = draws.map((d) => [
         d.bola1,
@@ -35,11 +40,19 @@ export default function Automatico() {
       router.push("/resultado");
     }
     run();
-  }, [router]);
+  }, [router, baseConcurso]);
 
   return (
     <main className="flex min-h-screen items-center justify-center">
       <p>Processando...</p>
     </main>
+  );
+}
+
+export default function Automatico() {
+  return (
+    <Suspense fallback={<p>Processando...</p>}>
+      <AutomaticoContent />
+    </Suspense>
   );
 }

--- a/gerasena.com/src/lib/historico.ts
+++ b/gerasena.com/src/lib/historico.ts
@@ -182,13 +182,13 @@ function computeFeatures(
   ];
 }
 
-export async function analyzeHistorico(): Promise<
-  Record<string, number | [number, number]>
-> {
+export async function analyzeHistorico(
+  before?: number
+): Promise<Record<string, number | [number, number]>> {
   const tf: typeof tfTypes = await import("@tensorflow/tfjs");
   const result: Record<string, number | [number, number]> = {};
   FEATURES.forEach((f) => (result[f] = 0));
-  const historico = await getHistorico(50);
+  const historico = await getHistorico(50, 0, before);
   if (historico.length < 2) return result;
 
   const draws = [...historico].reverse();


### PR DESCRIPTION
## Summary
- adjust automatic mode to analyze draws before the requested contest
- allow analyzeHistorico to accept an optional contest cutoff
- document how automatic mode bases its analysis on the selected contest

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688fdb99ecf0832f98faffc0d081f918