### PR TITLE
fix manual feature generation

### DIFF
--- a/gerasena.com/src/app/manual/page.tsx
+++ b/gerasena.com/src/app/manual/page.tsx
@@ -5,7 +5,7 @@ import { FEATURES } from "@/lib/features";
 import { FeatureSelector } from "@/components/FeatureSelector";
 import { generateGames } from "@/lib/genetic";
 import Link from "next/link";
-import type { Draw } from "@/lib/historico";
+import type { Draw, FeatureResult } from "@/lib/historico";
 
 const GROUP_SIZE = 4;
 const GROUPS = Array.from({ length: Math.ceil(FEATURES.length / GROUP_SIZE) }, (_v, i) =>
@@ -40,7 +40,13 @@ function ManualContent() {
     if (step < GROUPS.length - 1) {
       setStep(step + 1);
     } else {
-      const games = generateGames(selected);
+      const features: FeatureResult = {
+        histFreq: [],
+        prevDraw: [],
+        histPos: [],
+      };
+      Object.assign(features, selected);
+      const games = generateGames(features);
       const res = await fetch(
         `/api/historico?limit=50${baseConcurso ? `&before=${baseConcurso}` : ""}`
       );

--- a/gerasena.com/src/lib/historico.ts
+++ b/gerasena.com/src/lib/historico.ts
@@ -182,11 +182,11 @@ function computeFeatures(
   ];
 }
 
-export interface FeatureResult
-  extends Record<string, number | [number, number]> {
+export interface FeatureResult {
   histFreq: number[];
   prevDraw: number[];
   histPos: number[];
+  [key: string]: number | [number, number] | number[];
 }
 
 export async function analyzeHistorico(


### PR DESCRIPTION
## Summary
- build a full feature set before manual game generation
- allow historical analysis type to hold array-based features

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npx tsc -p tsconfig.json --noEmit`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68905b71f548832f97924e6d28dd1a66