### PR TITLE
feat: add constant for history limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Gerasena.com é uma aplicação completa para geração e análise de jogos da M
 
 - **Geração de jogos**
   - **Manual:** o usuário escolhe características estatísticas (soma, média, frequência histórica etc.) e o sistema cria combinações a partir desses critérios.
-  - **Automática:** o módulo `analyzeHistorico` usa [TensorFlow.js](https://www.tensorflow.org/js) para analisar os 50 sorteios anteriores ao concurso informado (ou os últimos disponíveis) e gerar combinações automaticamente.
+  - **Automática:** o módulo `analyzeHistorico` usa [TensorFlow.js](https://www.tensorflow.org/js) para analisar os últimos `QTD_HIST` sorteios (padrão 100) anteriores ao concurso informado (ou os últimos disponíveis) e gerar combinações automaticamente.
   - As combinações são avaliadas (`evaluator.ts`) e salvas na tabela `gerador` do banco de dados.
 - **Consulta de resultados**
   - Página de **histórico** com os últimos concursos e possibilidade de paginação via `/api/historico`.

--- a/gerasena.com/src/app/api/historico/route.ts
+++ b/gerasena.com/src/app/api/historico/route.ts
@@ -1,9 +1,13 @@
 import { NextResponse } from "next/server";
 import { getHistorico } from "@/lib/historico";
+import { QTD_HIST } from "@/lib/constants";
 
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
-  const limit = parseInt(searchParams.get("limit") ?? "50", 10);
+  const limit = parseInt(
+    searchParams.get("limit") ?? QTD_HIST.toString(),
+    10
+  );
   const offset = parseInt(searchParams.get("offset") ?? "0", 10);
   const beforeParam = searchParams.get("before");
   const before = beforeParam ? parseInt(beforeParam, 10) : undefined;

--- a/gerasena.com/src/app/automatico/page.tsx
+++ b/gerasena.com/src/app/automatico/page.tsx
@@ -3,6 +3,7 @@ import { useEffect, Suspense } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { generateGames } from "@/lib/genetic";
 import type { Draw } from "@/lib/historico";
+import { QTD_HIST } from "@/lib/constants";
 
 function AutomaticoContent() {
   const router = useRouter();
@@ -17,7 +18,9 @@ function AutomaticoContent() {
       const features = await analyzeHistorico(baseConcurso);
       const games = generateGames(features);
       const res = await fetch(
-        `/api/historico?limit=50${baseConcurso ? `&before=${baseConcurso}` : ""}`
+        `/api/historico?limit=${QTD_HIST}${
+          baseConcurso ? `&before=${baseConcurso}` : ""
+        }`
       );
       const draws: Draw[] = await res.json();
       const history = draws.map((d) => [

--- a/gerasena.com/src/app/historico/page.tsx
+++ b/gerasena.com/src/app/historico/page.tsx
@@ -1,9 +1,10 @@
 import { getHistorico } from "@/lib/historico";
 import Link from "next/link";
 import HistoricoTable from "@/components/HistoricoTable";
+import { QTD_HIST } from "@/lib/constants";
 
 export default async function Historico() {
-  const draws = await getHistorico(50);
+  const draws = await getHistorico(QTD_HIST);
   return (
     <main className="mx-auto max-w-3xl p-4 text-center">
       <h2 className="mb-4 text-xl font-semibold">Histórico</h2>

--- a/gerasena.com/src/app/manual/page.tsx
+++ b/gerasena.com/src/app/manual/page.tsx
@@ -6,6 +6,7 @@ import { FeatureSelector } from "@/components/FeatureSelector";
 import { generateGames } from "@/lib/genetic";
 import Link from "next/link";
 import type { Draw, FeatureResult } from "@/lib/historico";
+import { QTD_HIST } from "@/lib/constants";
 
 const GROUP_SIZE = 4;
 const GROUPS = Array.from({ length: Math.ceil(FEATURES.length / GROUP_SIZE) }, (_v, i) =>
@@ -48,7 +49,9 @@ function ManualContent() {
       Object.assign(features, selected);
       const games = generateGames(features);
       const res = await fetch(
-        `/api/historico?limit=50${baseConcurso ? `&before=${baseConcurso}` : ""}`
+        `/api/historico?limit=${QTD_HIST}${
+          baseConcurso ? `&before=${baseConcurso}` : ""
+        }`
       );
       const draws: Draw[] = await res.json();
       const history = draws.map((d) => [

--- a/gerasena.com/src/components/HistoricoTable.tsx
+++ b/gerasena.com/src/components/HistoricoTable.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { Draw } from "@/lib/historico";
+import { QTD_HIST } from "@/lib/constants";
 
 interface Props {
   initialDraws: Draw[];
@@ -16,7 +17,7 @@ export default function HistoricoTable({ initialDraws }: Props) {
 
   const loadMore = useCallback(async () => {
     setLoading(true);
-    const res = await fetch(`/api/historico?limit=50&offset=${offset}`);
+    const res = await fetch(`/api/historico?limit=${QTD_HIST}&offset=${offset}`);
     const data: Draw[] = await res.json();
     setDraws((prev) => [...prev, ...data]);
     setOffset((prev) => prev + data.length);

--- a/gerasena.com/src/lib/constants.ts
+++ b/gerasena.com/src/lib/constants.ts
@@ -1,0 +1,1 @@
+export const QTD_HIST = 100;

--- a/gerasena.com/src/lib/historico.ts
+++ b/gerasena.com/src/lib/historico.ts
@@ -1,5 +1,6 @@
 import { db } from "./db";
 import { FEATURES } from "./features";
+import { QTD_HIST } from "./constants";
 import type * as tfTypes from "@tensorflow/tfjs";
 
 export interface Draw {
@@ -14,7 +15,7 @@ export interface Draw {
 }
 
 export async function getHistorico(
-  limit = 50,
+  limit = QTD_HIST,
   offset = 0,
   before?: number
 ): Promise<Draw[]> {
@@ -199,7 +200,7 @@ export async function analyzeHistorico(
     histPos: [],
   };
   FEATURES.forEach((f) => (result[f] = 0));
-  const historico = await getHistorico(50, 0, before);
+  const historico = await getHistorico(QTD_HIST, 0, before);
   if (historico.length < 2) return result;
 
   const draws = [...historico].reverse();


### PR DESCRIPTION
## Summary
- add QTD_HIST constant set to 100
- replace hard-coded history limits with QTD_HIST
- document new constant in README

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6890636a5c20832fb40c7fd33df49422