### PR TITLE
feat: make generated game count configurable

### DIFF
--- a/gerasena.com/src/app/automatico/page.tsx
+++ b/gerasena.com/src/app/automatico/page.tsx
@@ -3,7 +3,7 @@ import { useEffect, Suspense } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { generateGames } from "@/lib/genetic";
 import type { Draw } from "@/lib/historico";
-import { QTD_HIST } from "@/lib/constants";
+import { QTD_HIST, QTD_GERAR } from "@/lib/constants";
 
 function AutomaticoContent() {
   const router = useRouter();
@@ -16,7 +16,7 @@ function AutomaticoContent() {
       const { analyzeHistorico } = await import("@/lib/historico");
       const { evaluateGames } = await import("@/lib/evaluator");
       const features = await analyzeHistorico(baseConcurso);
-      const games = generateGames(features);
+      const games = generateGames(features, QTD_GERAR);
       const res = await fetch(
         `/api/historico?limit=${QTD_HIST}${
           baseConcurso ? `&before=${baseConcurso}` : ""

--- a/gerasena.com/src/app/manual/page.tsx
+++ b/gerasena.com/src/app/manual/page.tsx
@@ -6,7 +6,7 @@ import { FeatureSelector } from "@/components/FeatureSelector";
 import { generateGames } from "@/lib/genetic";
 import Link from "next/link";
 import type { Draw, FeatureResult } from "@/lib/historico";
-import { QTD_HIST } from "@/lib/constants";
+import { QTD_HIST, QTD_GERAR } from "@/lib/constants";
 
 const GROUP_SIZE = 4;
 const GROUPS = Array.from({ length: Math.ceil(FEATURES.length / GROUP_SIZE) }, (_v, i) =>
@@ -47,7 +47,7 @@ function ManualContent() {
         histPos: [],
       };
       Object.assign(features, selected);
-      const games = generateGames(features);
+      const games = generateGames(features, QTD_GERAR);
       const res = await fetch(
         `/api/historico?limit=${QTD_HIST}${
           baseConcurso ? `&before=${baseConcurso}` : ""

--- a/gerasena.com/src/lib/constants.ts
+++ b/gerasena.com/src/lib/constants.ts
@@ -1,1 +1,8 @@
 export const QTD_HIST = 100;
+
+// Quantidade de jogos a serem gerados pelo algoritmo genético.
+// Pode ser ajustado via variável de ambiente `NEXT_PUBLIC_QTD_GERAR`.
+export const QTD_GERAR = parseInt(
+  process.env.NEXT_PUBLIC_QTD_GERAR || "100",
+  10,
+);


### PR DESCRIPTION
## Summary
- allow game generation count to be configured through `QTD_GERAR`
- use new constant in manual and automatic generation flows

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689068374080832faa9a42a1201ed0f1