### PR TITLE
Exclude latest draw from automatic predictions training data

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Gerasena.com é uma aplicação completa para geração e análise de jogos da M
 
 - **Geração de jogos**
   - **Manual:** o usuário escolhe características estatísticas (soma, média, frequência histórica etc.) e o sistema cria combinações a partir desses critérios.
-  - **Automática:** o módulo `analyzeHistorico` usa [TensorFlow.js](https://www.tensorflow.org/js) para analisar os últimos `QTD_HIST` sorteios (padrão 100) anteriores ao concurso informado (ou os últimos disponíveis) e gerar combinações automaticamente.
+  - **Automática:** o módulo `analyzeHistorico` usa [TensorFlow.js](https://www.tensorflow.org/js) para analisar os últimos `QTD_HIST` sorteios (padrão 100) anteriores ao concurso informado (ou os últimos disponíveis) e gerar combinações automaticamente. O número do último concurso é obtido e passado como `before` tanto para a análise quanto para a consulta em `/api/historico`, evitando que o sorteio previsto participe do treinamento ou de comparações.
   - As combinações são avaliadas (`evaluator.ts`) e salvas na tabela `gerador` do banco de dados.
 - **Consulta de resultados**
   - Página de **histórico** com os últimos concursos e possibilidade de paginação via `/api/historico`.

--- a/gerasena.com/src/app/automatico/page.tsx
+++ b/gerasena.com/src/app/automatico/page.tsx
@@ -19,12 +19,18 @@ function AutomaticoContent() {
     async function run() {
       const { analyzeHistorico } = await import("@/lib/historico");
       const { evaluateGames } = await import("@/lib/evaluator");
-      const features = await analyzeHistorico(baseConcurso);
+
+      // Sempre obtenha o número do último concurso para que o sorteio sendo
+      // previsto não faça parte dos dados de treino/avaliação.
+      const latestRes = await fetch("/api/historico?limit=1");
+      const latest: Draw[] = await latestRes.json();
+      const lastConcurso = latest[0]?.concurso;
+      const before = baseConcurso ?? lastConcurso;
+
+      const features = await analyzeHistorico(before);
       const games = generateGames(features, qtdGerar);
       const res = await fetch(
-        `/api/historico?limit=${QTD_HIST}${
-          baseConcurso ? `&before=${baseConcurso}` : ""
-        }`
+        `/api/historico?limit=${QTD_HIST}${before ? `&before=${before}` : ""}`
       );
       const draws: Draw[] = await res.json();
       const history = draws.map((d) => [


### PR DESCRIPTION
## Summary
- Always fetch the latest contest number and pass it as `before` to both `analyzeHistorico` and `/api/historico` in automatic mode.
- Document that the predicted draw is excluded from training and comparisons to avoid data leakage.

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689073a409c8832fa93f005d5ce198b0