### PR TITLE
feat: add optional target to generated games

### DIFF
--- a/gerasena.com/src/app/api/generated/route.ts
+++ b/gerasena.com/src/app/api/generated/route.ts
@@ -1,16 +1,27 @@
 import { NextResponse } from "next/server";
 import { saveGenerated, getGenerated } from "@/lib/generated";
 
-export async function GET() {
-  const data = await getGenerated();
+/**
+ * Returns stored games. Optionally filter by a target contest number or date
+ * via the `target` query parameter.
+ */
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const target = searchParams.get("target") ?? undefined;
+  const data = await getGenerated(target ?? undefined);
   return NextResponse.json(data);
 }
 
+/**
+ * Saves a generated game.
+ * Accepts a body with `numbers` and an optional `target` identifying the
+ * contest number or draw date the game is meant for.
+ */
 export async function POST(req: Request) {
-  const { numbers } = await req.json();
+  const { numbers, target } = await req.json();
   if (!Array.isArray(numbers)) {
     return NextResponse.json({ error: "numbers required" }, { status: 400 });
   }
-  await saveGenerated(numbers);
+  await saveGenerated(numbers, typeof target === "string" ? target : undefined);
   return NextResponse.json({ ok: true });
 }

--- a/gerasena.com/src/app/api/stats/route.ts
+++ b/gerasena.com/src/app/api/stats/route.ts
@@ -7,14 +7,34 @@ function parseBrDate(d: string): Date {
   return new Date(`${year}-${month}-${day}`);
 }
 
-export async function GET() {
+/**
+ * Returns hit statistics correlating generated games with actual draws.
+ * Optionally filter games by a contest number or date through the `target`
+ * query parameter.
+ */
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const target = searchParams.get("target") ?? undefined;
   const draws = await getHistorico(1000);
-  const generated = await getGenerated();
+  const generated = await getGenerated(target ?? undefined);
   const results = [] as { concurso: number; hits: number }[];
 
   for (const g of generated) {
-    const genDate = new Date(g.created_at);
-    const draw = draws.find((d) => parseBrDate(d.data) >= genDate);
+    let draw;
+    if (g.target) {
+      const contest = parseInt(g.target, 10);
+      if (!isNaN(contest)) {
+        draw = draws.find((d) => d.concurso === contest);
+      } else {
+        const targetDate = g.target.includes("/")
+          ? parseBrDate(g.target)
+          : new Date(g.target);
+        draw = draws.find((d) => parseBrDate(d.data) >= targetDate);
+      }
+    } else {
+      const genDate = new Date(g.created_at);
+      draw = draws.find((d) => parseBrDate(d.data) >= genDate);
+    }
     if (!draw) continue;
     const drawNums = [
       draw.bola1,

--- a/gerasena.com/src/lib/generated.ts
+++ b/gerasena.com/src/lib/generated.ts
@@ -4,6 +4,8 @@ export interface GeneratedRow {
   id: number;
   numbers: number[];
   created_at: string;
+  /** Optional contest number or target draw date associated with the game */
+  target?: string | null;
 }
 
 let initialized = false;
@@ -18,12 +20,33 @@ async function ensureTable(): Promise<void> {
     bola4 INT,
     bola5 INT,
     bola6 INT,
+    target TEXT,
     created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
   )`);
+
+  // ensure new column exists if table was created previously
+  try {
+    const cols = await db.execute(`PRAGMA table_info(gerador)`);
+    const hasTarget = (cols.rows as any[]).some((c: any) => c.name === "target");
+    if (!hasTarget) {
+      await db.execute(`ALTER TABLE gerador ADD COLUMN target TEXT`);
+    }
+  } catch {
+    // ignore errors from stubbed db clients
+  }
+
   initialized = true;
 }
 
-export async function saveGenerated(numbers: number[]): Promise<void> {
+/**
+ * Persist a generated game.
+ * @param numbers The six numbers that compose the game.
+ * @param target Optional contest number or target draw date associated with the game.
+ */
+export async function saveGenerated(
+  numbers: number[],
+  target?: string
+): Promise<void> {
   await ensureTable();
   // Garantir que os números sejam únicos e ordenados
   const unique = Array.from(new Set(numbers)).sort((a, b) => a - b);
@@ -37,19 +60,29 @@ export async function saveGenerated(numbers: number[]): Promise<void> {
   if ((exists.rows as unknown[]).length) return;
 
   await db.execute({
-    sql: `INSERT INTO gerador (bola1, bola2, bola3, bola4, bola5, bola6, created_at) VALUES (?, ?, ?, ?, ?, ?, datetime('now'))`,
-    args: unique,
+    sql: `INSERT INTO gerador (bola1, bola2, bola3, bola4, bola5, bola6, target, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, datetime('now'))`,
+    args: [...unique, target ?? null],
   });
 }
 
-export async function getGenerated(): Promise<GeneratedRow[]> {
+/**
+ * Retrieve generated games, optionally filtering by a target identifier.
+ * @param target Contest number or draw date to filter by.
+ */
+export async function getGenerated(target?: string): Promise<GeneratedRow[]> {
   await ensureTable();
-  const res = await db.execute(
-    `SELECT id, bola1, bola2, bola3, bola4, bola5, bola6, created_at FROM gerador ORDER BY id DESC`
-  );
+  const res = target
+    ? await db.execute({
+        sql: `SELECT id, bola1, bola2, bola3, bola4, bola5, bola6, target, created_at FROM gerador WHERE target = ? ORDER BY id DESC`,
+        args: [target],
+      })
+    : await db.execute(
+        `SELECT id, bola1, bola2, bola3, bola4, bola5, bola6, target, created_at FROM gerador ORDER BY id DESC`
+      );
   return res.rows.map((r: any) => ({
     id: r.id,
     numbers: [r.bola1, r.bola2, r.bola3, r.bola4, r.bola5, r.bola6].map((n: any) => parseInt(n, 10)),
+    target: r.target ?? null,
     created_at: r.created_at,
   }));
 }


### PR DESCRIPTION
## Summary
- allow storing generated games with an optional contest number or target date
- expose `target` filter in `/api/generated` and `/api/stats`
- correlate stats with draws using the stored target when available

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6890774512b0832faf23911cc7a88353