### PR TITLE
feat: add sum tolerance for game generation

### DIFF
--- a/gerasena.com/src/lib/constants.ts
+++ b/gerasena.com/src/lib/constants.ts
@@ -7,6 +7,13 @@ export const QTD_GERAR = 100;
 // Limite máximo de jogos que podem ser gerados pelo usuário.
 export const QTD_GERAR_MAX = 10000;
 
+// Tolerância aplicada à soma prevista ao gerar jogos.
+// Pode ser ajustada via variável de ambiente `NEXT_PUBLIC_SUM_TOLERANCE`.
+export const SUM_TOLERANCE = parseInt(
+  process.env.NEXT_PUBLIC_SUM_TOLERANCE || "5",
+  10
+);
+
 
 export const SITE_URL = "https://gerasena.com";
 

--- a/gerasena.com/src/lib/features.ts
+++ b/gerasena.com/src/lib/features.ts
@@ -32,7 +32,8 @@ export const FEATURE_INFO: Record<
 > = {
   sum: {
     label: "Soma",
-    description: "Soma de todos os números escolhidos.",
+    description:
+      "Soma de todos os números escolhidos. Pode ser usada com um valor alvo e uma tolerância configurável.",
   },
   mean: {
     label: "Média",

--- a/gerasena.com/src/lib/genetic.ts
+++ b/gerasena.com/src/lib/genetic.ts
@@ -1,5 +1,6 @@
 import { FEATURES } from "./features";
 import type { FeatureResult } from "./historico";
+import { SUM_TOLERANCE } from "./constants";
 
 const PRIMES = new Set([
   2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59,
@@ -202,9 +203,21 @@ function gameKey(game: number[]): string {
 export function generateGames(
   _features: FeatureResult,
   populationSize = 100,
-  generations = 50
+  generations = 50,
+  sumTolerance = SUM_TOLERANCE
 ): number[][] {
-  const sumRange = Array.isArray(_features.sum) ? _features.sum : null;
+  let sumRange: [number, number] | null = null;
+  if (typeof _features.sum === "number") {
+    sumRange = [
+      _features.sum - sumTolerance,
+      _features.sum + sumTolerance,
+    ];
+  } else if (Array.isArray(_features.sum)) {
+    sumRange = [
+      _features.sum[0] - sumTolerance,
+      _features.sum[1] + sumTolerance,
+    ];
+  }
   const population: number[][] = [];
   const seen = new Set<string>();
   let attempts = 0;

--- a/gerasena.com/src/lib/historico.ts
+++ b/gerasena.com/src/lib/historico.ts
@@ -265,7 +265,9 @@ export async function analyzeHistorico(
   FEATURES.forEach((f, i) => {
     result[f] = values[i];
   });
-  result.sum = sumRange;
+  // Preserve the predicted sum value from the neural network in `result.sum`.
+  // Store the historical min/max range separately for potential use.
+  result.sumRange = sumRange;
 
   const histPos = posSum.map((s, i) => (posCount[i] ? s / posCount[i] : 0));
   result.histFreq = freq;


### PR DESCRIPTION
## Summary
- preserve neural-network predicted sum and expose historical sum range
- allow generateGames to filter by target sum with configurable tolerance
- document sum feature and add SUM_TOLERANCE configuration

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6890775dab80832f889eeb6ac3bc70d4