### PR TITLE
Dispose of TensorFlow model after prediction

### DIFF
--- a/gerasena.com/src/lib/historico.ts
+++ b/gerasena.com/src/lib/historico.ts
@@ -274,6 +274,7 @@ export async function analyzeHistorico(
   result.prevDraw = prevDraw;
   result.histPos = histPos;
 
+  model.dispose();
   tf.dispose([xs, ys, last, prediction]);
   return result;
 }


### PR DESCRIPTION
## Summary
- Release the TensorFlow model after predictions to prevent resource leakage
- Keep disposal of tensors for inputs, targets, and predictions

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `TS_NODE_COMPILER_OPTIONS='{...}' node -r ts-node/register memory-test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68907b9477b8832fae7b80434d55f889