### PR TITLE
fix: handle invalid sum prediction in generator

### DIFF
--- a/gerasena.com/src/lib/genetic.ts
+++ b/gerasena.com/src/lib/genetic.ts
@@ -226,6 +226,16 @@ export function generateGames(
     ];
   }
 
+  if (sumRange) {
+    const min = Math.max(sumRange[0], 21);
+    const max = Math.min(sumRange[1], 345);
+    if (min > max) {
+      sumRange = null;
+    } else {
+      sumRange = [min, max];
+    }
+  }
+
   const population: number[][] = [];
   const seen = new Set<string>();
   let attempts = 0;


### PR DESCRIPTION
## Summary
- avoid impossible sum ranges when generating automatic games

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68907ecf8b00832f80708e7eaba9db94