### PR TITLE
Handle fetch failures in service worker

### DIFF
--- a/gerasena.com/public/sw.js
+++ b/gerasena.com/public/sw.js
@@ -12,7 +12,14 @@ self.addEventListener('activate', event => {
 });
 
 self.addEventListener('fetch', event => {
+  if (event.request.method !== 'GET') {
+    return;
+  }
+
   event.respondWith(
-    caches.match(event.request).then(response => response || fetch(event.request))
+    caches
+      .match(event.request)
+      .then(response => response || fetch(event.request))
+      .catch(() => caches.match('/'))
   );
 });


### PR DESCRIPTION
## Summary
- prevent service worker from intercepting non-GET requests and handle fetch errors with a cached fallback

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689080b50b50832f9530c5c7f724b370