### PR TITLE
Allow chronological history retrieval

### DIFF
--- a/gerasena.com/src/app/api/stats/route.ts
+++ b/gerasena.com/src/app/api/stats/route.ts
@@ -15,7 +15,7 @@ function parseBrDate(d: string): Date {
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
   const target = searchParams.get("target") ?? undefined;
-  const draws = await getHistorico(1000);
+  const draws = await getHistorico(1000, 0, undefined, false);
   const generated = await getGenerated(target ?? undefined);
   const results = [] as { concurso: number; hits: number }[];
 

--- a/gerasena.com/src/lib/historico.ts
+++ b/gerasena.com/src/lib/historico.ts
@@ -17,12 +17,14 @@ export interface Draw {
 export async function getHistorico(
   limit = QTD_HIST,
   offset = 0,
-  before?: number
+  before?: number,
+  desc = true
 ): Promise<Draw[]> {
   try {
+    const order = desc ? "DESC" : "ASC";
     const sql = before
-      ? `SELECT concurso, data, bola1, bola2, bola3, bola4, bola5, bola6 FROM history WHERE concurso < ? ORDER BY concurso DESC LIMIT ? OFFSET ?`
-      : `SELECT concurso, data, bola1, bola2, bola3, bola4, bola5, bola6 FROM history ORDER BY concurso DESC LIMIT ? OFFSET ?`;
+      ? `SELECT concurso, data, bola1, bola2, bola3, bola4, bola5, bola6 FROM history WHERE concurso < ? ORDER BY concurso ${order} LIMIT ? OFFSET ?`
+      : `SELECT concurso, data, bola1, bola2, bola3, bola4, bola5, bola6 FROM history ORDER BY concurso ${order} LIMIT ? OFFSET ?`;
     const res = await db.execute({
       sql,
       args: before ? [before, limit, offset] : [limit, offset],


### PR DESCRIPTION
## Summary
- make getHistorico support ascending or descending contest order
- fetch draws chronologically in stats API

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6890817b3e38832faa785ebceaa2fc3d