### PR TITLE
fix historico fetch when analyzing past contests

### DIFF
--- a/gerasena.com/src/app/automatico/page.tsx
+++ b/gerasena.com/src/app/automatico/page.tsx
@@ -23,7 +23,9 @@ function AutomaticoContent() {
 
       // Sempre obtenha o número do último concurso para que o sorteio sendo
       // previsto não faça parte dos dados de treino/avaliação.
-      const latestRes = await fetch("/api/historico?limit=1");
+      const latestRes = await fetch(
+        `/api/historico?limit=1${baseConcurso ? `&before=${baseConcurso}` : ""}`
+      );
       const latest: Draw[] = await latestRes.json();
       const lastConcurso = latest[0]?.concurso;
       const before = baseConcurso ?? lastConcurso;


### PR DESCRIPTION
## Summary
- ensure history API fetch respects selected contest when analyzing past draws

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_689086267ab4832f9e889b16768f1023