### PR TITLE
Handle invalid JSON in generated game API

### DIFF
--- a/gerasena.com/src/app/api/generated/route.ts
+++ b/gerasena.com/src/app/api/generated/route.ts
@@ -18,7 +18,16 @@ export async function GET(request: Request) {
  * contest number or draw date the game is meant for.
  */
 export async function POST(req: Request) {
-  const { numbers, target } = await req.json();
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "invalid JSON" }, { status: 400 });
+  }
+  const { numbers, target } = (body ?? {}) as {
+    numbers?: unknown;
+    target?: unknown;
+  };
   if (!Array.isArray(numbers)) {
     return NextResponse.json({ error: "numbers required" }, { status: 400 });
   }


### PR DESCRIPTION
## Summary
- prevent POST /api/generated from crashing on invalid JSON
- validate request body and return clear 400 errors

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68908c3d3280832fa265c51c1a05596f