### PR TITLE
Fix service worker redirecting automatic results to home

### DIFF
--- a/gerasena.com/public/sw.js
+++ b/gerasena.com/public/sw.js
@@ -16,10 +16,23 @@ self.addEventListener('fetch', event => {
     return;
   }
 
+  // Always go to the network for API requests so that failures don't
+  // return the cached home page and break JSON parsing in the app.
+  if (event.request.url.includes('/api/')) {
+    event.respondWith(fetch(event.request));
+    return;
+  }
+
   event.respondWith(
-    caches
-      .match(event.request)
-      .then(response => response || fetch(event.request))
-      .catch(() => caches.match('/'))
+    caches.match(event.request).then(response => {
+      if (response) return response;
+      return fetch(event.request).catch(() => {
+        // Only fall back to the cached index page for navigation requests.
+        if (event.request.mode === 'navigate') {
+          return caches.match('/');
+        }
+        return Response.error();
+      });
+    })
   );
 });


### PR DESCRIPTION
## Summary
- prevent the service worker from returning the cached homepage for API requests or non-navigation fetches
- avoid automatic generation steps being redirected back to the index page

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68908da082ec832fb7344a41fb4b3986