### PR TITLE
fix: use fs promises from fs module

### DIFF
--- a/gerasena.com/src/lib/historico.ts
+++ b/gerasena.com/src/lib/historico.ts
@@ -2,7 +2,7 @@ import { db } from "./db";
 import { FEATURES } from "./features";
 import { QTD_HIST } from "./constants";
 import type * as tfTypes from "@tensorflow/tfjs";
-import fs from "fs/promises";
+import { promises as fs } from "fs";
 import path from "path";
 
 export interface Draw {


### PR DESCRIPTION
## Summary
- fix fs import by using promises from fs

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build` *(fails: Module not found: Can't resolve 'fs')*


------
https://chatgpt.com/codex/tasks/task_e_689094dd8644832fa567ca08f97712e4