### PR TITLE
refactor: lazy fs import and server analyze endpoint

### DIFF
--- a/gerasena.com/src/app/api/analyze/route.ts
+++ b/gerasena.com/src/app/api/analyze/route.ts
@@ -1,0 +1,10 @@
+import { NextResponse } from "next/server";
+import { analyzeHistorico } from "@/lib/historico";
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const beforeParam = searchParams.get("before");
+  const before = beforeParam ? parseInt(beforeParam, 10) : undefined;
+  const features = await analyzeHistorico(before);
+  return NextResponse.json(features);
+}

--- a/gerasena.com/src/app/automatico/page.tsx
+++ b/gerasena.com/src/app/automatico/page.tsx
@@ -2,7 +2,7 @@
 import { useEffect, Suspense } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { generateGames } from "@/lib/genetic";
-import type { Draw } from "@/lib/historico";
+import type { Draw, FeatureResult } from "@/lib/historico";
 import { QTD_HIST, QTD_GERAR, QTD_GERAR_MAX } from "@/lib/constants";
 
 function AutomaticoContent() {
@@ -16,7 +16,6 @@ function AutomaticoContent() {
 
   useEffect(() => {
     async function run() {
-      const { analyzeHistorico } = await import("@/lib/historico");
       const { evaluateGames } = await import("@/lib/evaluator");
       console.log("analyzing historico with baseConcurso", baseConcurso);
       const latestRes = await fetch(
@@ -26,7 +25,10 @@ function AutomaticoContent() {
       const lastConcurso = latest[0]?.concurso;
       const before = lastConcurso;
 
-      const features = await analyzeHistorico(before);
+      const featuresRes = await fetch(
+        `/api/analyze${before ? `?before=${before}` : ""}`
+      );
+      const features: FeatureResult = await featuresRes.json();
       const games = generateGames(features, qtdGerar, undefined, seed);
       const res = await fetch(
         `/api/historico?limit=${QTD_HIST}${before ? `&before=${before}` : ""}`

--- a/gerasena.com/src/lib/historico.ts
+++ b/gerasena.com/src/lib/historico.ts
@@ -2,7 +2,6 @@ import { db } from "./db";
 import { FEATURES } from "./features";
 import { QTD_HIST } from "./constants";
 import type * as tfTypes from "@tensorflow/tfjs";
-import { promises as fs } from "fs";
 import path from "path";
 
 export interface Draw {
@@ -51,6 +50,7 @@ async function getHistoricoFromCsv(
   desc = true
 ): Promise<Draw[]> {
   const csvPath = path.join(process.cwd(), "public", "mega-sena.csv");
+  const fs = await import("fs/promises");
   const file = await fs.readFile(csvPath, "utf8");
   let draws: Draw[] = file
     .trim()


### PR DESCRIPTION
## Summary
- lazily load fs for historico CSV reading
- expose analyze endpoint and fetch features via API
- ensure historico is only type-imported in client components

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6890f409c160832f85790c5b75f4b8a0