### PR TITLE
Handle blocked database reads

### DIFF
--- a/gerasena.com/src/lib/generated.ts
+++ b/gerasena.com/src/lib/generated.ts
@@ -12,7 +12,8 @@ let initialized = false;
 
 async function ensureTable(): Promise<void> {
   if (initialized) return;
-  await db.execute(`CREATE TABLE IF NOT EXISTS gerador (
+  try {
+    await db.execute(`CREATE TABLE IF NOT EXISTS gerador (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     bola1 INT,
     bola2 INT,
@@ -24,15 +25,23 @@ async function ensureTable(): Promise<void> {
     created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
   )`);
 
-  // ensure new column exists if table was created previously
-  try {
-    const cols = await db.execute(`PRAGMA table_info(gerador)`);
-    const hasTarget = (cols.rows as any[]).some((c: any) => c.name === "target");
-    if (!hasTarget) {
-      await db.execute(`ALTER TABLE gerador ADD COLUMN target TEXT`);
+    // ensure new column exists if table was created previously
+    try {
+      const cols = await db.execute(`PRAGMA table_info(gerador)`);
+      const hasTarget = (cols.rows as any[]).some((c: any) => c.name === "target");
+      if (!hasTarget) {
+        await db.execute(`ALTER TABLE gerador ADD COLUMN target TEXT`);
+      }
+    } catch {
+      // ignore errors from stubbed db clients
     }
-  } catch {
-    // ignore errors from stubbed db clients
+  } catch (error) {
+    if (
+      !("code" in (error as any) && (error as any).code === "BLOCKED") &&
+      !(error instanceof Error && /SQL read operations are forbidden/i.test(error.message))
+    ) {
+      throw error;
+    }
   }
 
   initialized = true;
@@ -52,17 +61,27 @@ export async function saveGenerated(
   const unique = Array.from(new Set(numbers)).sort((a, b) => a - b);
   if (unique.length !== 6) return;
 
-  // Evitar inserir jogos já existentes
-  const exists = await db.execute({
-    sql: `SELECT 1 FROM gerador WHERE bola1 = ? AND bola2 = ? AND bola3 = ? AND bola4 = ? AND bola5 = ? AND bola6 = ? LIMIT 1`,
-    args: unique,
-  });
-  if ((exists.rows as unknown[]).length) return;
+  try {
+    // Evitar inserir jogos já existentes
+    const exists = await db.execute({
+      sql: `SELECT 1 FROM gerador WHERE bola1 = ? AND bola2 = ? AND bola3 = ? AND bola4 = ? AND bola5 = ? AND bola6 = ? LIMIT 1`,
+      args: unique,
+    });
+    if ((exists.rows as unknown[]).length) return;
 
-  await db.execute({
-    sql: `INSERT INTO gerador (bola1, bola2, bola3, bola4, bola5, bola6, target, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, datetime('now'))`,
-    args: [...unique, target ?? null],
-  });
+    await db.execute({
+      sql: `INSERT INTO gerador (bola1, bola2, bola3, bola4, bola5, bola6, target, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, datetime('now'))`,
+      args: [...unique, target ?? null],
+    });
+  } catch (error) {
+    if (
+      ("code" in (error as any) && (error as any).code === "BLOCKED") ||
+      (error instanceof Error && /SQL read operations are forbidden/i.test(error.message))
+    ) {
+      return;
+    }
+    throw error;
+  }
 }
 
 /**
@@ -71,18 +90,28 @@ export async function saveGenerated(
  */
 export async function getGenerated(target?: string): Promise<GeneratedRow[]> {
   await ensureTable();
-  const res = target
-    ? await db.execute({
-        sql: `SELECT id, bola1, bola2, bola3, bola4, bola5, bola6, target, created_at FROM gerador WHERE target = ? ORDER BY id DESC`,
-        args: [target],
-      })
-    : await db.execute(
-        `SELECT id, bola1, bola2, bola3, bola4, bola5, bola6, target, created_at FROM gerador ORDER BY id DESC`
-      );
-  return res.rows.map((r: any) => ({
-    id: r.id,
-    numbers: [r.bola1, r.bola2, r.bola3, r.bola4, r.bola5, r.bola6].map((n: any) => parseInt(n, 10)),
-    target: r.target ?? null,
-    created_at: r.created_at,
-  }));
+  try {
+    const res = target
+      ? await db.execute({
+          sql: `SELECT id, bola1, bola2, bola3, bola4, bola5, bola6, target, created_at FROM gerador WHERE target = ? ORDER BY id DESC`,
+          args: [target],
+        })
+      : await db.execute(
+          `SELECT id, bola1, bola2, bola3, bola4, bola5, bola6, target, created_at FROM gerador ORDER BY id DESC`
+        );
+    return res.rows.map((r: any) => ({
+      id: r.id,
+      numbers: [r.bola1, r.bola2, r.bola3, r.bola4, r.bola5, r.bola6].map((n: any) => parseInt(n, 10)),
+      target: r.target ?? null,
+      created_at: r.created_at,
+    }));
+  } catch (error) {
+    if (
+      ("code" in (error as any) && (error as any).code === "BLOCKED") ||
+      (error instanceof Error && /SQL read operations are forbidden/i.test(error.message))
+    ) {
+      return [];
+    }
+    throw error;
+  }
 }

--- a/gerasena.com/src/lib/historico.ts
+++ b/gerasena.com/src/lib/historico.ts
@@ -36,7 +36,13 @@ export async function getHistorico(
     }
     return await getHistoricoFromCsv(limit, offset, before, desc);
   } catch (error) {
-    if (error instanceof Error && /no such table: history/i.test(error.message)) {
+    if (
+      error instanceof Error &&
+      (/no such table: history/i.test(error.message) ||
+        /SQL read operations are forbidden/i.test(error.message) ||
+        // libSQL errors expose a `code` property we can check for blocked operations
+        ("code" in error && (error as any).code === "BLOCKED"))
+    ) {
       return await getHistoricoFromCsv(limit, offset, before, desc);
     }
     throw error;


### PR DESCRIPTION
## Summary
- fallback to CSV when database reads are blocked
- ignore blocked DB operations in generated data helpers

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6890f7a2b034832f9cd458563ce7acfb