### PR TITLE
Cache service worker paths for automatic and result pages

### DIFF
--- a/gerasena.com/public/sw.js
+++ b/gerasena.com/public/sw.js
@@ -1,5 +1,5 @@
 const CACHE_NAME = 'gerasena-cache-v1';
-const URLS_TO_CACHE = ['/'];
+const URLS_TO_CACHE = ['/', '/automatico', '/resultado'];
 
 self.addEventListener('install', event => {
   event.waitUntil(


### PR DESCRIPTION
## Summary
- cache `/automatico` and `/resultado` pages in the service worker so navigation doesn't fall back to the home page

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6890ff80a8bc832f8c297837c6a87a67