### PR TITLE
feat: optimize history insert with INSERT OR IGNORE

### DIFF
--- a/gerasena.com/src/app/api/scrap/route.ts
+++ b/gerasena.com/src/app/api/scrap/route.ts
@@ -34,18 +34,19 @@ export async function GET() {
       bola6 INT
     )`);
 
-    const existing = await db.execute({
-      sql: "SELECT 1 FROM history WHERE concurso = ?",
-      args: [concurso],
+    await db.execute({
+      sql: `INSERT OR IGNORE INTO history (
+              concurso,
+              data,
+              bola1,
+              bola2,
+              bola3,
+              bola4,
+              bola5,
+              bola6
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+      args: [concurso, drawDate, b1, b2, b3, b4, b5, b6],
     });
-
-    if (existing.rows.length === 0) {
-      await db.execute({
-        sql: `INSERT INTO history (concurso, data, bola1, bola2, bola3, bola4, bola5, bola6)
-               VALUES (?, ?, ?, ?, ?, ?, ?, ?)` ,
-        args: [concurso, drawDate, b1, b2, b3, b4, b5, b6],
-      });
-    }
 
     return NextResponse.json({ ok: true });
   } catch (err) {


### PR DESCRIPTION
## Summary
- simplify history write logic by using `INSERT OR IGNORE` instead of pre-check query
- keep `concurso` as primary key for deduplication

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6891051f6de0832fbd912b9af461494b