### PR TITLE
feat: enforce unique generated games

### DIFF
--- a/gerasena.com/scripts/seed-turso.js
+++ b/gerasena.com/scripts/seed-turso.js
@@ -29,8 +29,13 @@ async function seed() {
     bola4 INT,
     bola5 INT,
     bola6 INT,
+    target TEXT,
     created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
   )`);
+
+  await db.execute(
+    `CREATE UNIQUE INDEX IF NOT EXISTS idx_gerador_unique ON gerador (bola1, bola2, bola3, bola4, bola5, bola6)`
+  );
 
   const lines = fs.readFileSync(CSV_PATH, 'utf8').trim().split('\n').slice(1);
   for (const line of lines) {

--- a/gerasena.com/src/lib/generated.ts
+++ b/gerasena.com/src/lib/generated.ts
@@ -35,6 +35,11 @@ async function ensureTable(): Promise<void> {
     } catch {
       // ignore errors from stubbed db clients
     }
+
+    // ensure uniqueness across all six number columns
+    await db.execute(
+      `CREATE UNIQUE INDEX IF NOT EXISTS idx_gerador_unique ON gerador (bola1, bola2, bola3, bola4, bola5, bola6)`
+    );
   } catch (error) {
     if (
       !("code" in (error as any) && (error as any).code === "BLOCKED") &&
@@ -62,15 +67,8 @@ export async function saveGenerated(
   if (unique.length !== 6) return;
 
   try {
-    // Evitar inserir jogos já existentes
-    const exists = await db.execute({
-      sql: `SELECT 1 FROM gerador WHERE bola1 = ? AND bola2 = ? AND bola3 = ? AND bola4 = ? AND bola5 = ? AND bola6 = ? LIMIT 1`,
-      args: unique,
-    });
-    if ((exists.rows as unknown[]).length) return;
-
     await db.execute({
-      sql: `INSERT INTO gerador (bola1, bola2, bola3, bola4, bola5, bola6, target, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, datetime('now'))`,
+      sql: `INSERT OR IGNORE INTO gerador (bola1, bola2, bola3, bola4, bola5, bola6, target, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, datetime('now'))`,
       args: [...unique, target ?? null],
     });
   } catch (error) {


### PR DESCRIPTION
## Summary
- ensure `gerador` table has a composite unique index on its six number columns
- replace duplicate check with `INSERT OR IGNORE` when saving generated games
- align seed script with new schema and index

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689105256dd0832f996ddfec7fab7013