### PR TITLE
Fix historico cache and API routes

### DIFF
--- a/gerasena.com/src/app/api/scrap/route.ts
+++ b/gerasena.com/src/app/api/scrap/route.ts
@@ -35,24 +35,15 @@ export async function GET() {
       bola6 INT
     )`);
 
-    await db.execute({
-      sql: `INSERT OR IGNORE INTO history (
-              concurso,
-              data,
-              bola1,
-              bola2,
-              bola3,
-              bola4,
-              bola5,
-              bola6
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
-      args: [concurso, drawDate, b1, b2, b3, b4, b5, b6],
+    const existing = await db.execute({
+      sql: `SELECT concurso FROM history WHERE concurso = ?`,
+      args: [concurso],
     });
 
     if (existing.rows.length === 0) {
       await db.execute({
         sql: `INSERT INTO history (concurso, data, bola1, bola2, bola3, bola4, bola5, bola6)
-               VALUES (?, ?, ?, ?, ?, ?, ?, ?)` ,
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
         args: [concurso, drawDate, b1, b2, b3, b4, b5, b6],
       });
       // New draw inserted, refresh cache

--- a/gerasena.com/src/app/api/stats/route.ts
+++ b/gerasena.com/src/app/api/stats/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { getHistoricoCached, type Draw } from "@/lib/historico";
+import { getCachedHistorico, type Draw } from "@/lib/historico";
 
 import { getGenerated } from "@/lib/generated";
 
@@ -17,7 +17,7 @@ export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
   const target = searchParams.get("target") ?? undefined;
 
-  const draws = await getCachedHistorico(1000, 0, undefined, false);
+  const { draws, drawIndex } = await loadDraws();
 
   const generated = await getGenerated(target ?? undefined);
   const results = [] as { concurso: number; hits: number }[];
@@ -59,7 +59,7 @@ let cachedIndex: Map<number, Draw> | null = null;
 
 async function loadDraws() {
   if (!cachedDraws) {
-    cachedDraws = await getHistoricoCached(1000, 0, undefined, false);
+    cachedDraws = await getCachedHistorico(1000, 0, undefined, false);
     cachedIndex = new Map(cachedDraws.map((d) => [d.concurso, d]));
   }
   return { draws: cachedDraws, drawIndex: cachedIndex! };


### PR DESCRIPTION
## Summary
- fix history caching module by exposing getCachedHistorico, adding invalidateHistoricoCache, and adding CSV fallback
- update stats API to load draws via cache and remove outdated imports
- clean up scrap API to avoid duplicate inserts and invalidate cache when new draw inserted

## Testing
- `npm test`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68910825cb84832f8bf80c6ffe32e7e9