### PR TITLE
Include target in generated game requests

### DIFF
--- a/gerasena.com/src/app/automatico/page.tsx
+++ b/gerasena.com/src/app/automatico/page.tsx
@@ -52,7 +52,7 @@ function AutomaticoContent() {
         fetch("/api/generated", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ numbers: g.numbers }),
+          body: JSON.stringify({ numbers: g.numbers, target: String(before) }),
         });
       }
       sessionStorage.setItem("results", JSON.stringify(evaluated));


### PR DESCRIPTION
## Summary
- include target contest number when posting generated games
- verify generated API already supports optional target field

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_689114e947ac832fa52fb79ae1006277