### PR TITLE
fix: dynamically load three for falling logos

### DIFF
--- a/gerasena.com/src/components/FallingLogosBackground.tsx
+++ b/gerasena.com/src/components/FallingLogosBackground.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useEffect, useRef } from "react";
-import * as THREE from "three";
 
 export default function FallingLogosBackground() {
   const mountRef = useRef<HTMLDivElement>(null);
@@ -10,82 +9,90 @@ export default function FallingLogosBackground() {
     const mount = mountRef.current;
     if (!mount) return;
 
-    const width = window.innerWidth;
-    const height = window.innerHeight;
+    let renderer: import("three").WebGLRenderer | undefined;
+    let cleanupResize: (() => void) | undefined;
 
-    const scene = new THREE.Scene();
-    const camera = new THREE.OrthographicCamera(
-      width / -2,
-      width / 2,
-      height / 2,
-      height / -2,
-      1,
-      1000,
-    );
-    camera.position.z = 10;
+    import("three").then((THREE) => {
+      const width = window.innerWidth;
+      const height = window.innerHeight;
 
-    const renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true });
-    renderer.setSize(width, height);
-    mount.appendChild(renderer.domElement);
-
-    const textureLoader = new THREE.TextureLoader();
-    const logoTexture = textureLoader.load("/logo.png");
-
-    const logos: THREE.Sprite[] = [];
-    const LOGO_COUNT = 20;
-
-    function createLogo() {
-      const material = new THREE.SpriteMaterial({ map: logoTexture });
-      const sprite = new THREE.Sprite(material);
-      const size = 64;
-      sprite.scale.set(size, size, 1);
-      sprite.position.set(
-        Math.random() * width - width / 2,
-        height / 2 + Math.random() * height,
-        0,
+      const scene = new THREE.Scene();
+      const camera = new THREE.OrthographicCamera(
+        width / -2,
+        width / 2,
+        height / 2,
+        height / -2,
+        1,
+        1000,
       );
-      sprite.userData = {
-        vy: 1 + Math.random() * 2,
-        rot: (Math.random() - 0.5) * 0.02,
+      camera.position.z = 10;
+
+      renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true });
+      renderer.setSize(width, height);
+      mount.appendChild(renderer.domElement);
+
+      const textureLoader = new THREE.TextureLoader();
+      const logoTexture = textureLoader.load("/logo.png");
+
+      const logos: import("three").Sprite[] = [];
+      const LOGO_COUNT = 20;
+
+      function createLogo() {
+        const material = new THREE.SpriteMaterial({ map: logoTexture });
+        const sprite = new THREE.Sprite(material);
+        const size = 64;
+        sprite.scale.set(size, size, 1);
+        sprite.position.set(
+          Math.random() * width - width / 2,
+          height / 2 + Math.random() * height,
+          0,
+        );
+        sprite.userData = {
+          vy: 1 + Math.random() * 2,
+          rot: (Math.random() - 0.5) * 0.02,
+        };
+        scene.add(sprite);
+        logos.push(sprite);
+      }
+
+      for (let i = 0; i < LOGO_COUNT; i += 1) {
+        createLogo();
+      }
+
+      const animate = () => {
+        requestAnimationFrame(animate);
+        logos.forEach((logo) => {
+          logo.position.y -= logo.userData.vy as number;
+          logo.rotation.z += logo.userData.rot as number;
+          if (logo.position.y < -height / 2 - 100) {
+            logo.position.y = height / 2 + Math.random() * height;
+            logo.position.x = Math.random() * width - width / 2;
+          }
+        });
+        renderer!.render(scene, camera);
       };
-      scene.add(sprite);
-      logos.push(sprite);
-    }
+      animate();
 
-    for (let i = 0; i < LOGO_COUNT; i += 1) {
-      createLogo();
-    }
-
-    const animate = () => {
-      requestAnimationFrame(animate);
-      logos.forEach((logo) => {
-        logo.position.y -= logo.userData.vy as number;
-        logo.rotation.z += logo.userData.rot as number;
-        if (logo.position.y < -height / 2 - 100) {
-          logo.position.y = height / 2 + Math.random() * height;
-          logo.position.x = Math.random() * width - width / 2;
-        }
-      });
-      renderer.render(scene, camera);
-    };
-    animate();
-
-    const handleResize = () => {
-      const newWidth = window.innerWidth;
-      const newHeight = window.innerHeight;
-      renderer.setSize(newWidth, newHeight);
-      camera.left = newWidth / -2;
-      camera.right = newWidth / 2;
-      camera.top = newHeight / 2;
-      camera.bottom = newHeight / -2;
-      camera.updateProjectionMatrix();
-    };
-    window.addEventListener("resize", handleResize);
+      const handleResize = () => {
+        const newWidth = window.innerWidth;
+        const newHeight = window.innerHeight;
+        renderer!.setSize(newWidth, newHeight);
+        camera.left = newWidth / -2;
+        camera.right = newWidth / 2;
+        camera.top = newHeight / 2;
+        camera.bottom = newHeight / -2;
+        camera.updateProjectionMatrix();
+      };
+      window.addEventListener("resize", handleResize);
+      cleanupResize = () => window.removeEventListener("resize", handleResize);
+    });
 
     return () => {
-      window.removeEventListener("resize", handleResize);
-      mount.removeChild(renderer.domElement);
-      renderer.dispose();
+      cleanupResize?.();
+      if (renderer) {
+        mount.removeChild(renderer.domElement);
+        renderer.dispose();
+      }
     };
   }, []);
 


### PR DESCRIPTION
## Summary
- dynamically import `three` for the falling logos background so it runs purely on the client

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689117c03678832f82a13e646c837e49