### PR TITLE
Use historical sum range when generating games

### DIFF
--- a/gerasena.com/src/lib/genetic.ts
+++ b/gerasena.com/src/lib/genetic.ts
@@ -217,7 +217,12 @@ export function generateGames(
   const rng = seed ? seedrandom(seed) : Math.random;
 
   let sumRange: [number, number] | null = null;
-  if (typeof _features.sum === "number") {
+  if (Array.isArray(_features.sumRange)) {
+    sumRange = [
+      _features.sumRange[0] - sumTolerance,
+      _features.sumRange[1] + sumTolerance,
+    ];
+  } else if (typeof _features.sum === "number") {
     sumRange = [_features.sum - sumTolerance, _features.sum + sumTolerance];
   } else if (Array.isArray(_features.sum)) {
     sumRange = [

--- a/gerasena.com/src/lib/historico.ts
+++ b/gerasena.com/src/lib/historico.ts
@@ -292,7 +292,9 @@ export interface FeatureResult {
   histFreq: number[];
   prevDraw: number[];
   histPos: number[];
-  [key: string]: number | [number, number] | number[];
+  /** Historical min/max range for draw sums */
+  sumRange?: [number, number];
+  [key: string]: number | [number, number] | number[] | undefined;
 }
 
 export async function analyzeHistorico(


### PR DESCRIPTION
## Summary
- use historical draw sum range when constraining generated games
- expose `sumRange` on feature results

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689119277050832f8e781661c27483b9