### PR TITLE
Update automatic generation to target next draw

### DIFF
--- a/gerasena.com/src/app/automatico/page.tsx
+++ b/gerasena.com/src/app/automatico/page.tsx
@@ -27,7 +27,8 @@ function AutomaticoContent() {
       );
       const latest: Draw[] = await latestRes.json();
       const lastConcurso = latest[0]?.concurso;
-      const before = baseConcurso ?? lastConcurso;
+      const before =
+        baseConcurso ?? (lastConcurso !== undefined ? lastConcurso + 1 : undefined);
 
       const featuresRes = await fetch(
         `/api/analyze${


### PR DESCRIPTION
## Summary
- adjust automatic game generation to analyze history before next contest

## Testing
- `npm --prefix gerasena.com run lint`

------
https://chatgpt.com/codex/tasks/task_e_68911e5f5970832f84af913ac455b491