### PR TITLE
Fix historical draw retrieval for past contests

### DIFF
--- a/gerasena.com/src/app/automatico/page.tsx
+++ b/gerasena.com/src/app/automatico/page.tsx
@@ -20,27 +20,17 @@ function AutomaticoContent() {
     async function run() {
       const { evaluateGames } = await import("@/lib/evaluator");
       console.log("analyzing historico with baseConcurso", baseConcurso);
-      const latestRes = await fetch(
-        `/api/historico?limit=${QTD_HIST}${
-          baseConcurso ? `&before=${baseConcurso}` : ""
-        }`
-      );
+      const latestRes = await fetch(`/api/historico?limit=1`);
       const latest: Draw[] = await latestRes.json();
       const lastConcurso = latest[0]?.concurso;
-      const before = baseConcurso ?? lastConcurso;
+      const before = (baseConcurso ?? lastConcurso) + 1;
 
-      const featuresRes = await fetch(
-        `/api/analyze${
-          before !== undefined ? `?before=${before}` : ""
-        }`
-      );
+      const featuresRes = await fetch(`/api/analyze?before=${before}`);
       const features: FeatureResult = await featuresRes.json();
       const generations = qtdGerar > 5000 ? 80 : 50;
       const games = generateGames(features, qtdGerar, generations, seed);
       const res = await fetch(
-        `/api/historico?limit=${QTD_HIST}${
-          before !== undefined ? `&before=${before}` : ""
-        }`
+        `/api/historico?limit=${QTD_HIST}&before=${before}`
       );
       const draws: Draw[] = await res.json();
       const history = draws.map((d) => [

--- a/gerasena.com/src/app/manual/page.tsx
+++ b/gerasena.com/src/app/manual/page.tsx
@@ -65,7 +65,7 @@ function ManualContent() {
       );
       const res = await fetch(
         `/api/historico?limit=${QTD_HIST}${
-          baseConcurso ? `&before=${baseConcurso}` : ""
+          baseConcurso ? `&before=${baseConcurso + 1}` : ""
         }`
       );
       const draws: Draw[] = await res.json();


### PR DESCRIPTION
## Summary
- ensure old contest requests include the selected draw by advancing the `before` parameter
- compute upcoming contest number in automatic generation to use correct training history

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68911eba4060832fa8754528ec202339