### PR TITLE
Prevent using current draw in history analysis

### DIFF
--- a/gerasena.com/src/app/automatico/page.tsx
+++ b/gerasena.com/src/app/automatico/page.tsx
@@ -24,7 +24,8 @@ function AutomaticoContent() {
       const latest: Draw[] = await latestRes.json();
       const lastConcurso = latest[0]?.concurso;
 
-      const before = (baseConcurso ?? lastConcurso) + 1;
+      const before =
+        baseConcurso !== undefined ? baseConcurso : lastConcurso + 1;
 
 
       const featuresRes = await fetch(`/api/analyze?before=${before}`);

--- a/gerasena.com/src/app/manual/page.tsx
+++ b/gerasena.com/src/app/manual/page.tsx
@@ -65,7 +65,7 @@ function ManualContent() {
       );
       const res = await fetch(
         `/api/historico?limit=${QTD_HIST}${
-          baseConcurso ? `&before=${baseConcurso + 1}` : ""
+          baseConcurso ? `&before=${baseConcurso}` : ""
         }`
       );
       const draws: Draw[] = await res.json();


### PR DESCRIPTION
## Summary
- avoid including target concurso in automatic analysis
- skip target concurso in manual generation

## Testing
- `npm test 2>&1 | tail -n 20`
- `npm run lint >/tmp/lint.log && tail -n 20 /tmp/lint.log`


------
https://chatgpt.com/codex/tasks/task_e_689122ba45f4832f85fa5d27c8e17d87