### PR TITLE
refactor: drop low-value lottery features

### DIFF
--- a/gerasena.com/public/lottery_ga.py
+++ b/gerasena.com/public/lottery_ga.py
@@ -5,27 +5,23 @@ Genetic Algorithms. Each combination (game) consists of 6 unique numbers
 between 1 and 60. The algorithm evolves an initial random population to
 approximate user-specified statistical characteristics.
 
-The 20 characteristics considered are:
-1. Sum of numbers
-2. Arithmetic mean
-3. Median
-4. Historical mode (max frequency in historical data)
-5. Range (max - min)
-6. Standard deviation
-7. Percentage of even numbers
-8. Percentage of odd numbers
-9. Percentage of primes
-10. Frequency per quadrant (1-15,16-30,31-45,46-60)
-11. Count of sequential number pairs
-12. Average distance between consecutive numbers
-13. Minimum distance between consecutive numbers
-14. Maximum distance between consecutive numbers
-15. Count of numbers repeated from previous draw
-16. Average historical frequency of numbers
-17. Sum of digits of numbers
-18. Frequency of last digits (0-9)
-19. Average historical position of numbers
-20. Frequency per tens group (1-10,...,51-60)
+The 16 characteristics considered are:
+1. Historical mode (max frequency in historical data)
+2. Range (max - min)
+3. Standard deviation
+4. Percentage of even numbers
+5. Percentage of odd numbers
+6. Percentage of primes
+7. Frequency per quadrant (1-15,16-30,31-45,46-60)
+8. Count of sequential number pairs
+9. Average distance between consecutive numbers
+10. Minimum distance between consecutive numbers
+11. Maximum distance between consecutive numbers
+12. Count of numbers repeated from previous draw
+13. Average historical frequency of numbers
+14. Frequency of last digits (0-9)
+15. Average historical position of numbers
+16. Frequency per tens group (1-10,...,51-60)
 
 The script can optionally receive a JSON file with desired feature values.
 If not provided, a random target is generated for demonstration purposes.
@@ -60,15 +56,6 @@ PRIMES = {2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59}
 # -------------------------------------
 # Feature calculation helpers
 # -------------------------------------
-
-def feature_sum(game: Sequence[int]) -> int:
-    return int(sum(game))
-
-def feature_mean(game: Sequence[int]) -> float:
-    return float(np.mean(game))
-
-def feature_median(game: Sequence[int]) -> float:
-    return float(np.median(game))
 
 def feature_historical_mode(game: Sequence[int], hist_freq: Sequence[int]) -> int:
     return max(hist_freq[n - 1] for n in game)
@@ -125,9 +112,6 @@ def feature_repetition_prev(game: Sequence[int], prev_draw: Sequence[int]) -> in
 def feature_avg_hist_freq(game: Sequence[int], hist_freq: Sequence[int]) -> float:
     return float(np.mean([hist_freq[n - 1] for n in game]))
 
-def feature_sum_digits(game: Sequence[int]) -> int:
-    return sum(sum(int(d) for d in str(n)) for n in game)
-
 def feature_last_digit_freq(game: Sequence[int]) -> List[int]:
     counts = [0] * 10
     for n in game:
@@ -145,9 +129,6 @@ def feature_tens_group(game: Sequence[int]) -> List[int]:
 
 # Mapping of feature names to functions
 FEATURE_FUNCTIONS = {
-    "sum": lambda g, h: feature_sum(g),
-    "mean": lambda g, h: feature_mean(g),
-    "median": lambda g, h: feature_median(g),
     "mode_hist": lambda g, h: feature_historical_mode(g, h.freq),
     "range": lambda g, h: feature_range(g),
     "std": lambda g, h: feature_std(g),
@@ -161,7 +142,6 @@ FEATURE_FUNCTIONS = {
     "max_distance": lambda g, h: feature_max_distance(g),
     "repeat_prev": lambda g, h: feature_repetition_prev(g, h.prev_draw),
     "avg_hist_freq": lambda g, h: feature_avg_hist_freq(g, h.freq),
-    "sum_digits": lambda g, h: feature_sum_digits(g),
     "last_digit_counts": lambda g, h: feature_last_digit_freq(g),
     "avg_hist_position": lambda g, h: feature_hist_avg_position(g, h.position),
     "tens_group_counts": lambda g, h: feature_tens_group(g),

--- a/gerasena.com/src/lib/features.ts
+++ b/gerasena.com/src/lib/features.ts
@@ -2,9 +2,6 @@ import type { FeatureResult } from "./historico";
 import { computeFeatures } from "./genetic";
 
 export const FEATURES = [
-  "sum",
-  "mean",
-  "median",
   "mode_hist",
   "range",
   "std",
@@ -19,13 +16,10 @@ export const FEATURES = [
   "repeat_prev",
   "repeat_hist",
   "avg_hist_freq",
-  "sum_digits",
   "last_digit_counts",
   "avg_hist_position",
   "tens_group_counts",
   "mirror_numbers",
-  "sum_odd_positions",
-  "sum_even_positions",
   "hot_cold_balance",
 ];
 
@@ -33,19 +27,6 @@ export const FEATURE_INFO: Record<
   string,
   { label: string; description: string }
 > = {
-  sum: {
-    label: "Soma",
-    description:
-      "Soma de todos os números escolhidos. Pode ser usada com um valor alvo e uma tolerância configurável.",
-  },
-  mean: {
-    label: "Média",
-    description: "Média aritmética dos números escolhidos.",
-  },
-  median: {
-    label: "Mediana",
-    description: "Valor central dos números em ordem.",
-  },
   mode_hist: {
     label: "Moda histórica",
     description: "Número que mais apareceu nos sorteios anteriores.",
@@ -102,10 +83,6 @@ export const FEATURE_INFO: Record<
     label: "Freq. histórica média",
     description: "Média de frequência histórica dos números.",
   },
-  sum_digits: {
-    label: "Soma dos dígitos",
-    description: "Soma dos dígitos de cada número.",
-  },
   last_digit_counts: {
     label: "Dígitos finais",
     description: "Distribuição dos dígitos finais.",
@@ -121,14 +98,6 @@ export const FEATURE_INFO: Record<
   mirror_numbers: {
     label: "Números espelhados",
     description: "Quantidade de pares espelhados no jogo, como 12 e 21.",
-  },
-  sum_odd_positions: {
-    label: "Soma posições ímpares",
-    description: "Soma dos números que ocupam posições ímpares no jogo.",
-  },
-  sum_even_positions: {
-    label: "Soma posições pares",
-    description: "Soma dos números que ocupam posições pares no jogo.",
   },
   hot_cold_balance: {
     label: "Balanceamento quente/frio",

--- a/gerasena.com/src/lib/genetic.ts
+++ b/gerasena.com/src/lib/genetic.ts
@@ -64,9 +64,6 @@ export function computeFeatures(
   histPos: number[]
 ): Record<string, number> {
   const sorted = [...game].sort((a, b) => a - b);
-  const sum = sorted.reduce((a, b) => a + b, 0);
-  const mean = sum / sorted.length;
-  const median = (sorted[2] + sorted[3]) / 2;
   const modeHist = Math.max(...sorted.map((n) => histFreq[n - 1] || 0));
   const range = sorted[sorted.length - 1] - sorted[0];
   const sd = std(sorted);
@@ -92,15 +89,6 @@ export function computeFeatures(
   const repeatHist = sorted.filter((n) => (histFreq[n - 1] || 0) > 0).length;
   const avgHistFreq =
     sorted.reduce((acc, n) => acc + (histFreq[n - 1] || 0), 0) / sorted.length;
-  const sumDigits = sorted.reduce(
-    (acc, n) =>
-      acc +
-      n
-        .toString()
-        .split("")
-        .reduce((a, d) => a + parseInt(d, 10), 0),
-    0
-  );
   const lastDigitCounts = Array(10).fill(0);
   sorted.forEach((n) => lastDigitCounts[n % 10]++);
   const lastDigitStd = std(lastDigitCounts);
@@ -121,13 +109,6 @@ export function computeFeatures(
       mirrorCount++;
     }
   });
-
-  const sumOddPositions = sorted
-    .filter((_n, i) => i % 2 === 0)
-    .reduce((a, b) => a + b, 0);
-  const sumEvenPositions = sorted
-    .filter((_n, i) => i % 2 === 1)
-    .reduce((a, b) => a + b, 0);
 
   const freqPairs = histFreq.map((freq, i) => ({ num: i + 1, freq }));
   const hotNumbers = new Set(
@@ -161,9 +142,6 @@ export function computeFeatures(
   const hotColdBalance = hotAvg - coldAvg;
 
   return {
-    sum,
-    mean,
-    median,
     mode_hist: modeHist,
     range,
     std: sd,
@@ -178,13 +156,10 @@ export function computeFeatures(
     repeat_prev: repeatPrev,
     repeat_hist: repeatHist,
     avg_hist_freq: avgHistFreq,
-    sum_digits: sumDigits,
     last_digit_counts: lastDigitStd,
     avg_hist_position: avgHistPos,
     tens_group_counts: tensGroupStd,
     mirror_numbers: mirrorCount,
-    sum_odd_positions: sumOddPositions,
-    sum_even_positions: sumEvenPositions,
     hot_cold_balance: hotColdBalance,
   };
 }
@@ -198,7 +173,6 @@ function fitness(game: number[], features: FeatureResult): number {
   );
   let error = 0;
   for (const f of FEATURES) {
-    if (f === "sum") continue;
     const target = features[f];
     if (typeof target === "number") {
       const diff = values[f] - target;


### PR DESCRIPTION
## Summary
- prune statistical features like sum and mean
- simplify feature computation and historical analysis
- streamline genetic algorithm inputs

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689155ef1dfc832fa775c1a60939e914