### PR TITLE
Use contest and date in export filename

### DIFF
--- a/gerasena.com/src/app/automatico/page.tsx
+++ b/gerasena.com/src/app/automatico/page.tsx
@@ -52,6 +52,11 @@ function AutomaticoContent() {
           body: JSON.stringify({ numbers: g.numbers, target: String(before) }),
         });
       }
+      sessionStorage.setItem("concurso", String(before));
+      sessionStorage.setItem(
+        "concursoDate",
+        new Date().toISOString().slice(0, 10)
+      );
       sessionStorage.setItem("results", JSON.stringify(evaluated));
       router.push("/resultado");
     }

--- a/gerasena.com/src/app/manual/page.tsx
+++ b/gerasena.com/src/app/manual/page.tsx
@@ -86,6 +86,13 @@ function ManualContent() {
           body: JSON.stringify({ numbers: g.numbers }),
         });
       });
+      const targetConcurso =
+        baseConcurso !== undefined ? baseConcurso : draws[0].concurso + 1;
+      sessionStorage.setItem("concurso", String(targetConcurso));
+      sessionStorage.setItem(
+        "concursoDate",
+        new Date().toISOString().slice(0, 10)
+      );
       sessionStorage.setItem("results", JSON.stringify(evaluated));
       router.push("/resultado");
     }

--- a/gerasena.com/src/app/resultado/page.tsx
+++ b/gerasena.com/src/app/resultado/page.tsx
@@ -24,8 +24,12 @@ export default function Resultado() {
     const blob = new Blob([content], { type: "text/plain" });
     const url = URL.createObjectURL(blob);
     const a = document.createElement("a");
+    const concurso = sessionStorage.getItem("concurso") || "0";
+    const data =
+      sessionStorage.getItem("concursoDate") ||
+      new Date().toISOString().slice(0, 10);
     a.href = url;
-    a.download = "jogos.txt";
+    a.download = `concurso_${concurso}_${data}.txt`;
     a.click();
     URL.revokeObjectURL(url);
   }


### PR DESCRIPTION
## Summary
- include contest info and date when exporting TXT results
- save contest metadata in manual and automatic generation flows

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68915cd11b84832f967fa0a9e083e33e