### PR TITLE
refactor: use range for features

### DIFF
--- a/gerasena.com/src/app/manual/page.tsx
+++ b/gerasena.com/src/app/manual/page.tsx
@@ -16,9 +16,7 @@ const GROUPS = Array.from(
 
 function ManualContent() {
   const [step, setStep] = useState(0);
-  const [selected, setSelected] = useState<
-    Record<string, number | [number, number]>
-  >({});
+  const [selected, setSelected] = useState<Record<string, [number, number]>>({});
   const router = useRouter();
   const searchParams = useSearchParams();
   const concursoParam = searchParams.get("concurso");
@@ -36,13 +34,13 @@ function ManualContent() {
       if (f in next) {
         delete next[f];
       } else {
-        next[f] = f === "sum" ? [0, 0] : 0;
+        next[f] = [0, 0];
       }
       return next;
     });
   };
 
-  const setValue = (f: string, value: number | [number, number]) => {
+  const setValue = (f: string, value: [number, number]) => {
     setSelected((prev) => ({ ...prev, [f]: value }));
   };
 

--- a/gerasena.com/src/components/FeatureSelector.tsx
+++ b/gerasena.com/src/components/FeatureSelector.tsx
@@ -2,9 +2,9 @@
 
 interface Props {
   features: string[];
-  selected: Record<string, number | [number, number]>;
+  selected: Record<string, [number, number]>;
   onToggle: (feature: string) => void;
-  onChange: (feature: string, value: number | [number, number]) => void;
+  onChange: (feature: string, value: [number, number]) => void;
 }
 
 import { FEATURE_INFO } from "@/lib/features";
@@ -13,10 +13,9 @@ export function FeatureSelector({ features, selected, onToggle, onChange }: Prop
   return (
     <div className="grid grid-cols-1 gap-2">
       {features.map((f) => {
-        const isRange = f === "sum";
         const active = f in selected;
         const value = selected[f];
-        const [min, max] = Array.isArray(value) ? value : ["", ""];
+        const [min, max] = value ?? ["", ""];
         return (
           <div key={f} className="flex items-center gap-2">
             <input
@@ -36,37 +35,27 @@ export function FeatureSelector({ features, selected, onToggle, onChange }: Prop
             >
               i
             </button>
-            {isRange ? (
-              <div className="ml-auto flex items-center gap-1">
-                <input
-                  type="number"
-                  className="w-20 rounded border px-1 py-0.5"
-                  value={min as number | string}
-                  disabled={!active}
-                  onChange={(e) =>
-                    onChange(f, [Number(e.target.value), Number(max || 0)])
-                  }
-                />
-                <span>-</span>
-                <input
-                  type="number"
-                  className="w-20 rounded border px-1 py-0.5"
-                  value={max as number | string}
-                  disabled={!active}
-                  onChange={(e) =>
-                    onChange(f, [Number(min || 0), Number(e.target.value)])
-                  }
-                />
-              </div>
-            ) : (
+            <div className="ml-auto flex items-center gap-1">
               <input
                 type="number"
-                className="ml-auto w-20 rounded border px-1 py-0.5"
-                value={(value as number) ?? ""}
+                className="w-20 rounded border px-1 py-0.5"
+                value={min as number | string}
                 disabled={!active}
-                onChange={(e) => onChange(f, Number(e.target.value))}
+                onChange={(e) =>
+                  onChange(f, [Number(e.target.value), Number(max || 0)])
+                }
               />
-            )}
+              <span>-</span>
+              <input
+                type="number"
+                className="w-20 rounded border px-1 py-0.5"
+                value={max as number | string}
+                disabled={!active}
+                onChange={(e) =>
+                  onChange(f, [Number(min || 0), Number(e.target.value)])
+                }
+              />
+            </div>
           </div>
         );
       })}

--- a/gerasena.com/src/lib/genetic.ts
+++ b/gerasena.com/src/lib/genetic.ts
@@ -173,10 +173,16 @@ function fitness(game: number[], features: FeatureResult): number {
   );
   let error = 0;
   for (const f of FEATURES) {
-    const target = features[f];
-    if (typeof target === "number") {
-      const diff = values[f] - target;
-      error += diff * diff;
+    const range = features[f];
+    if (Array.isArray(range)) {
+      const value = values[f];
+      if (value < range[0]) {
+        const diff = range[0] - value;
+        error += diff * diff;
+      } else if (value > range[1]) {
+        const diff = value - range[1];
+        error += diff * diff;
+      }
     }
   }
   return -error;


### PR DESCRIPTION
## Summary
- use min/max ranges for all features and derive ranges from historical standard deviation
- update genetic algorithm fitness to respect feature ranges
- adapt manual selection UI to accept feature ranges

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689162e4c02c832fab8eab4765481658