### PR TITLE
feat: stabilize analysis with seeding and validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Gerasena.com é uma aplicação completa para geração e análise de jogos da M
 
 - **Geração de jogos**
   - **Manual:** o usuário escolhe características estatísticas (soma, média, frequência histórica etc.) e o sistema cria combinações a partir desses critérios.
-  - **Automática:** o módulo `analyzeHistorico` usa [TensorFlow.js](https://www.tensorflow.org/js) para analisar os últimos `QTD_HIST` sorteios (padrão 100) anteriores ao concurso informado (ou os últimos disponíveis) e gerar combinações automaticamente. O número do último concurso é obtido e passado como `before` tanto para a análise quanto para a consulta em `/api/historico`, evitando que o sorteio previsto participe do treinamento ou de comparações.
+  - **Automática:** o módulo `analyzeHistorico` usa [TensorFlow.js](https://www.tensorflow.org/js) para analisar os últimos `QTD_HIST` sorteios (padrão 200) anteriores ao concurso informado (ou os últimos disponíveis) e gerar combinações automaticamente. O treinamento agora utiliza uma semente fixa e validação interna para reduzir variação entre execuções. O número do último concurso é obtido e passado como `before` tanto para a análise quanto para a consulta em `/api/historico`, evitando que o sorteio previsto participe do treinamento ou de comparações.
   - As combinações são avaliadas (`evaluator.ts`) e salvas na tabela `gerador` do banco de dados.
 - **Consulta de resultados**
   - Página de **histórico** com os últimos concursos e possibilidade de paginação via `/api/historico`.

--- a/gerasena.com/public/lottery_ga.py
+++ b/gerasena.com/public/lottery_ga.py
@@ -29,9 +29,10 @@ If not provided, a random target is generated for demonstration purposes.
 
 from __future__ import annotations
 
+import argparse
 import json
+import os
 import random
-import sys
 from dataclasses import dataclass
 from typing import Dict, List, Sequence, Tuple
 
@@ -244,9 +245,17 @@ def random_historical_data() -> HistoricalData:
     return HistoricalData(freq=freq, prev_draw=prev_draw, position=position)
 
 def main():
+    parser = argparse.ArgumentParser(description="Lottery GA")
+    parser.add_argument("target", nargs="?", help="JSON file with target features")
+    parser.add_argument("--seed", type=int, default=int(os.environ.get("LOTTERY_SEED", 42)))
+    args = parser.parse_args()
+
+    random.seed(args.seed)
+    np.random.seed(args.seed)
+
     hist = random_historical_data()
-    if len(sys.argv) > 1:
-        desired = load_target_features(sys.argv[1])
+    if args.target:
+        desired = load_target_features(args.target)
     else:
         # Generate a random target for demonstration
         sample_game = tuple(sorted(random.sample(range(1, 61), 6)))

--- a/gerasena.com/src/lib/constants.ts
+++ b/gerasena.com/src/lib/constants.ts
@@ -1,9 +1,9 @@
 // src/lib/constants.ts
 // Constantes usadas no projeto Gerasena
 
-// Quantidade de jogos que serão analisados pela IA para prever as
-// características dos jogos passados.
-export const QTD_HIST = 50;
+// Quantidade de sorteios analisados para prever o próximo resultado.
+// Um histórico maior torna o modelo menos suscetível a oscilações.
+export const QTD_HIST = 200;
 
 // Quantidade de jogos a serem gerados pelo algoritmo genético.
 export const QTD_GERAR = 100;


### PR DESCRIPTION
## Summary
- widen draw history used in prediction to reduce volatility
- add global seed, dropout layers, and validation split to neural model
- allow GA script seeding and document deterministic training

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689169c6bc34832f8af23a5272286a3c