### PR TITLE
feat: expose mutation rate

### DIFF
--- a/gerasena.com/src/app/automatico/page.tsx
+++ b/gerasena.com/src/app/automatico/page.tsx
@@ -15,6 +15,8 @@ function AutomaticoContent() {
     ? Math.min(Math.max(parseInt(qtdParam, 10), 1), QTD_GERAR_MAX)
     : QTD_GERAR;
   const seed = searchParams.get("seed") || undefined;
+  const mutationParam = searchParams.get("mutationRate");
+  const mutationRate = mutationParam ? parseFloat(mutationParam) : 0.1;
 
   useEffect(() => {
     async function run() {
@@ -31,7 +33,13 @@ function AutomaticoContent() {
       const featuresRes = await fetch(`/api/analyze?before=${before}`);
       const features: FeatureResult = await featuresRes.json();
       const generations = qtdGerar > 5000 ? 80 : 50;
-      const games = generateGames(features, qtdGerar, generations, seed);
+      const games = generateGames(
+        features,
+        qtdGerar,
+        generations,
+        seed,
+        mutationRate
+      );
       const res = await fetch(
         `/api/historico?limit=${QTD_HIST}&before=${before}`
       );
@@ -61,7 +69,7 @@ function AutomaticoContent() {
       router.push("/resultado");
     }
     run();
-  }, [router, baseConcurso, qtdGerar, seed]);
+  }, [router, baseConcurso, qtdGerar, seed, mutationRate]);
 
   return (
     <main className="flex min-h-screen items-center justify-center">

--- a/gerasena.com/src/app/manual/page.tsx
+++ b/gerasena.com/src/app/manual/page.tsx
@@ -27,6 +27,8 @@ function ManualContent() {
     : QTD_GERAR;
   const seedParam = searchParams.get("seed") || "";
   const [seed, setSeed] = useState(seedParam);
+  const mutationParam = searchParams.get("mutationRate") || "0.1";
+  const [mutationRate, setMutationRate] = useState(parseFloat(mutationParam));
 
   const toggle = (f: string) => {
     setSelected((prev) => {
@@ -59,7 +61,8 @@ function ManualContent() {
         features,
         qtdGerar,
         generations,
-        seed || undefined
+        seed || undefined,
+        mutationRate
       );
       const res = await fetch(
         `/api/historico?limit=${QTD_HIST}${
@@ -112,6 +115,16 @@ function ManualContent() {
         value={seed}
         onChange={(e) => setSeed(e.target.value)}
         placeholder="Semente (opcional)"
+        className="rounded border px-2 py-1"
+      />
+      <input
+        type="number"
+        step="0.01"
+        min="0"
+        max="1"
+        value={mutationRate}
+        onChange={(e) => setMutationRate(parseFloat(e.target.value))}
+        placeholder="Taxa de mutação"
         className="rounded border px-2 py-1"
       />
       <button

--- a/gerasena.com/src/lib/genetic.ts
+++ b/gerasena.com/src/lib/genetic.ts
@@ -46,8 +46,13 @@ function crossover(
   return uniqueGame(Array.from(set));
 }
 
-function mutate(rng: () => number, game: number[], allowed: number[]) {
-  if (rng() < 0.1) {
+function mutate(
+  rng: () => number,
+  game: number[],
+  allowed: number[],
+  mutationRate: number
+) {
+  if (rng() < mutationRate) {
     const idx = rand(rng, 0, 5);
     let n = allowed[rand(rng, 0, allowed.length - 1)];
     while (game.includes(n)) n = allowed[rand(rng, 0, allowed.length - 1)];
@@ -197,6 +202,7 @@ export function generateGames(
   populationSize = 100,
   generations = 50,
   seed?: string,
+  mutationRate = 0.1,
   sumTolerance = SUM_TOLERANCE
 ): number[][] {
   const rng = seed ? seedrandom(seed) : Math.random;
@@ -276,7 +282,7 @@ export function generateGames(
       const a = survivors[rand(rng, 0, survivors.length - 1)];
       const b = survivors[rand(rng, 0, survivors.length - 1)];
       const child = crossover(rng, a, b, allowed);
-      mutate(rng, child, allowed);
+      mutate(rng, child, allowed, mutationRate);
       const sum = child.reduce((acc, n) => acc + n, 0);
       if (sumRange && (sum < sumRange[0] || sum > sumRange[1])) continue;
       const key = gameKey(child);


### PR DESCRIPTION
## Summary
- add configurable mutation rate to genetic generation
- allow query string or manual input to override mutation rate

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689176939f40832f80180789451ba9d4