### PR TITLE
feat: add single-point crossover

### DIFF
--- a/gerasena.com/package.json
+++ b/gerasena.com/package.json
@@ -7,6 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
+    "test": "node tests/crossover.test.js",
     "scrape:mega-sena": "ts-node scripts/mega-sena-cron.ts",
     "seed:turso": "node scripts/seed-turso.js",
     "seed:history": "node scripts/populate-history.js"

--- a/gerasena.com/src/lib/genetic.ts
+++ b/gerasena.com/src/lib/genetic.ts
@@ -33,13 +33,15 @@ function randomGame(rng: () => number, allowed: number[]): number[] {
   return uniqueGame(Array.from(set));
 }
 
-function crossover(
+export function crossover(
   rng: () => number,
   a: number[],
   b: number[],
   allowed: number[]
 ): number[] {
-  const set = new Set([...a.slice(0, 3), ...b.slice(3)]);
+  const point = rand(rng, 1, 5);
+  const genes = [...a.slice(0, point), ...b.slice(point)];
+  const set = new Set(genes.filter((n) => allowed.includes(n)));
   while (set.size < 6) {
     set.add(allowed[rand(rng, 0, allowed.length - 1)]);
   }

--- a/gerasena.com/tests/crossover.test.js
+++ b/gerasena.com/tests/crossover.test.js
@@ -1,0 +1,22 @@
+process.env.TS_NODE_COMPILER_OPTIONS = '{"module":"commonjs","moduleResolution":"node"}';
+require('ts-node/register');
+const assert = require('node:assert');
+const seedrandom = require('seedrandom');
+const { crossover } = require('../src/lib/genetic');
+
+const allowed = Array.from({ length: 12 }, (_, i) => i + 1);
+
+let rng = seedrandom('seed');
+const a = [1, 2, 3, 4, 5, 6];
+const b = [7, 8, 9, 10, 11, 12];
+const child = crossover(rng, a, b, allowed);
+assert.deepStrictEqual(child, [1, 2, 3, 10, 11, 12]);
+
+rng = seedrandom('seed');
+const a2 = [1, 2, 99, 4, 5, 6];
+const b2 = [7, 8, 9, 10, 11, 12];
+const child2 = crossover(rng, a2, b2, allowed);
+assert.equal(child2.length, 6);
+assert(child2.every((n) => allowed.includes(n)));
+
+console.log('crossover tests passed');


### PR DESCRIPTION
## Summary
- implement single-point crossover that respects allowed numbers
- add test case and npm test script

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6891785f2bcc832fab7d709efe6da16f